### PR TITLE
lib/millicode: procedure prologues and epilogues

### DIFF
--- a/cmd/hello/hello.S
+++ b/cmd/hello/hello.S
@@ -4,6 +4,7 @@
 # A classic. Also useful to check that basic IO and safe_str work.
 # ===========================================================================
 
+.include "inc/millicode.S"
 .include "inc/io.S"
 .include "inc/safe_str.S"
 
@@ -16,10 +17,7 @@ safe_str greeting, "Hello, primordial world!\n"
 .global main
 main:
 	.cfi_startproc
-	addi sp, sp, -16
-	sd fp, 0(sp)
-	mv fp, sp
-	sd ra, 8(fp)
+	save_0
 
 	li a0, STDOUT
 	la a1, greeting
@@ -29,9 +27,6 @@ main:
 	# Return error from io.Write.
 	mv a0, a1
 
-	ld ra, 8(fp)
-	ld fp, 0(fp)
-	addi sp, sp, 16
-	ret
+	restore_0
 	.cfi_endproc
 

--- a/inc/millicode.S
+++ b/inc/millicode.S
@@ -1,0 +1,333 @@
+# ===========================================================================
+# Millicode for procedure prologue and epilogue (save and restore macros)
+# ===========================================================================
+
+# Avoid using .equ or #define for the frame size to avoid polluting the
+# namespace of user code.
+
+.section .text
+
+.macro save_0
+	# Use alternate calling convention using t0 to avoid clobbering ra.
+	jal t0, prologue_0
+	.cfi_def_cfa_offset 0x10
+	.cfi_offset fp, 0x00 - 0x10
+	.cfi_offset ra, 0x08 - 0x10
+.endm
+
+.macro save_1
+	# Use alternate calling convention using t0 to avoid clobbering ra.
+	jal t0, prologue_1
+	.cfi_def_cfa_offset 0x20
+	.cfi_offset fp, 0x00 - 0x20
+	.cfi_offset ra, 0x08 - 0x20
+	.cfi_offset s1, 0x10 - 0x20
+.endm
+
+.macro save_2
+	# Use alternate calling convention using t0 to avoid clobbering ra.
+	jal t0, prologue_2
+	.cfi_def_cfa_offset 0x20
+	.cfi_offset fp, 0x00 - 0x20
+	.cfi_offset ra, 0x08 - 0x20
+	.cfi_offset s1, 0x10 - 0x20
+	.cfi_offset s2, 0x18 - 0x20
+.endm
+
+.macro save_3
+	# Use alternate calling convention using t0 to avoid clobbering ra.
+	jal t0, prologue_3
+	.cfi_def_cfa_offset 0x30
+	.cfi_offset fp, 0x00 - 0x30
+	.cfi_offset ra, 0x08 - 0x30
+	.cfi_offset s1, 0x10 - 0x30
+	.cfi_offset s2, 0x18 - 0x30
+	.cfi_offset s3, 0x20 - 0x30
+.endm
+
+.macro save_4
+	# Use alternate calling convention using t0 to avoid clobbering ra.
+	jal t0, prologue_4
+	.cfi_def_cfa_offset 0x30
+	.cfi_offset fp, 0x00 - 0x30
+	.cfi_offset ra, 0x08 - 0x30
+	.cfi_offset s1, 0x10 - 0x30
+	.cfi_offset s2, 0x18 - 0x30
+	.cfi_offset s3, 0x20 - 0x30
+	.cfi_offset s4, 0x28 - 0x30
+.endm
+
+.macro save_5
+	# Use alternate calling convention using t0 to avoid clobbering ra.
+	jal t0, prologue_5
+	.cfi_def_cfa_offset 0x40
+	.cfi_offset fp, 0x00 - 0x40
+	.cfi_offset ra, 0x08 - 0x40
+	.cfi_offset s1, 0x10 - 0x40
+	.cfi_offset s2, 0x18 - 0x40
+	.cfi_offset s3, 0x20 - 0x40
+	.cfi_offset s4, 0x28 - 0x40
+	.cfi_offset s5, 0x30 - 0x40
+.endm
+
+.macro save_6
+	# Use alternate calling convention using t0 to avoid clobbering ra.
+	jal t0, prologue_6
+	.cfi_def_cfa_offset 0x40
+	.cfi_offset fp, 0x00 - 0x40
+	.cfi_offset ra, 0x08 - 0x40
+	.cfi_offset s1, 0x10 - 0x40
+	.cfi_offset s2, 0x18 - 0x40
+	.cfi_offset s3, 0x20 - 0x40
+	.cfi_offset s4, 0x28 - 0x40
+	.cfi_offset s5, 0x30 - 0x40
+	.cfi_offset s6, 0x38 - 0x40
+.endm
+
+.macro save_7
+	# Use alternate calling convention using t0 to avoid clobbering ra.
+	jal t0, prologue_7
+	.cfi_def_cfa_offset 0x50
+	.cfi_offset fp, 0x00 - 0x50
+	.cfi_offset ra, 0x08 - 0x50
+	.cfi_offset s1, 0x10 - 0x50
+	.cfi_offset s2, 0x18 - 0x50
+	.cfi_offset s3, 0x20 - 0x50
+	.cfi_offset s4, 0x28 - 0x50
+	.cfi_offset s5, 0x30 - 0x50
+	.cfi_offset s6, 0x38 - 0x50
+	.cfi_offset s7, 0x40 - 0x50
+.endm
+
+.macro save_8
+	# Use alternate calling convention using t0 to avoid clobbering ra.
+	jal t0, prologue_8
+	.cfi_def_cfa_offset 0x50
+	.cfi_offset fp, 0x00 - 0x50
+	.cfi_offset ra, 0x08 - 0x50
+	.cfi_offset s1, 0x10 - 0x50
+	.cfi_offset s2, 0x18 - 0x50
+	.cfi_offset s3, 0x20 - 0x50
+	.cfi_offset s4, 0x28 - 0x50
+	.cfi_offset s5, 0x30 - 0x50
+	.cfi_offset s6, 0x38 - 0x50
+	.cfi_offset s7, 0x40 - 0x50
+	.cfi_offset s8, 0x48 - 0x50
+.endm
+
+.macro save_9
+	# Use alternate calling convention using t0 to avoid clobbering ra.
+	jal t0, prologue_9
+	.cfi_def_cfa_offset 0x60
+	.cfi_offset fp, 0x00 - 0x60
+	.cfi_offset ra, 0x08 - 0x60
+	.cfi_offset s1, 0x10 - 0x60
+	.cfi_offset s2, 0x18 - 0x60
+	.cfi_offset s3, 0x20 - 0x60
+	.cfi_offset s4, 0x28 - 0x60
+	.cfi_offset s5, 0x30 - 0x60
+	.cfi_offset s6, 0x38 - 0x60
+	.cfi_offset s7, 0x40 - 0x60
+	.cfi_offset s8, 0x48 - 0x60
+	.cfi_offset s9, 0x50 - 0x60
+.endm
+
+.macro save_10
+	# Use alternate calling convention using t0 to avoid clobbering ra.
+	jal t0, prologue_10
+	.cfi_def_cfa_offset 0x60
+	.cfi_offset fp, 0x00 - 0x60
+	.cfi_offset ra, 0x08 - 0x60
+	.cfi_offset s1, 0x10 - 0x60
+	.cfi_offset s2, 0x18 - 0x60
+	.cfi_offset s3, 0x20 - 0x60
+	.cfi_offset s4, 0x28 - 0x60
+	.cfi_offset s5, 0x30 - 0x60
+	.cfi_offset s6, 0x38 - 0x60
+	.cfi_offset s7, 0x40 - 0x60
+	.cfi_offset s8, 0x48 - 0x60
+	.cfi_offset s9, 0x50 - 0x60
+	.cfi_offset s10, 0x58 - 0x60
+.endm
+
+.macro save_11
+	# Use alternate calling convention using t0 to avoid clobbering ra.
+	jal t0, prologue_11
+	.cfi_def_cfa_offset 0x70
+	.cfi_offset fp, 0x00 - 0x70
+	.cfi_offset ra, 0x08 - 0x70
+	.cfi_offset s1, 0x10 - 0x70
+	.cfi_offset s2, 0x18 - 0x70
+	.cfi_offset s3, 0x20 - 0x70
+	.cfi_offset s4, 0x28 - 0x70
+	.cfi_offset s5, 0x30 - 0x70
+	.cfi_offset s6, 0x38 - 0x70
+	.cfi_offset s7, 0x40 - 0x70
+	.cfi_offset s8, 0x48 - 0x70
+	.cfi_offset s9, 0x50 - 0x70
+	.cfi_offset s10, 0x58 - 0x70
+	.cfi_offset s10, 0x60 - 0x70
+.endm
+
+.macro restore_0
+	# Tailcall into millicode.
+	j epilogue_0
+	.cfi_restore ra
+	.cfi_restore fp
+	.cfi_def_cfa_offset 0
+.endm
+
+.macro restore_1
+	# Tailcall into millicode.
+	j epilogue_1
+	.cfi_restore s1
+	.cfi_restore ra
+	.cfi_restore fp
+	.cfi_def_cfa_offset 0
+.endm
+
+.macro restore_2
+	# Tailcall into millicode.
+	j epilogue_2
+	.cfi_restore s2
+	.cfi_restore s1
+	.cfi_restore ra
+	.cfi_restore fp
+	.cfi_def_cfa_offset 0
+.endm
+
+.macro restore_3
+	# Tailcall into millicode.
+	j epilogue_3
+	.cfi_restore s3
+	.cfi_restore s2
+	.cfi_restore s1
+	.cfi_restore ra
+	.cfi_restore fp
+	.cfi_def_cfa_offset 0
+.endm
+
+.macro restore_4
+	# Tailcall into millicode.
+	j epilogue_4
+	.cfi_restore s4
+	.cfi_restore s3
+	.cfi_restore s2
+	.cfi_restore s1
+	.cfi_restore ra
+	.cfi_restore fp
+	.cfi_def_cfa_offset 0
+.endm
+
+.macro restore_5
+	# Tailcall into millicode.
+	j epilogue_5
+	.cfi_restore s5
+	.cfi_restore s4
+	.cfi_restore s3
+	.cfi_restore s2
+	.cfi_restore s1
+	.cfi_restore ra
+	.cfi_restore fp
+	.cfi_def_cfa_offset 0
+.endm
+
+.macro restore_6
+	# Tailcall into millicode.
+	j epilogue_6
+	.cfi_restore s6
+	.cfi_restore s5
+	.cfi_restore s4
+	.cfi_restore s3
+	.cfi_restore s2
+	.cfi_restore s1
+	.cfi_restore ra
+	.cfi_restore fp
+	.cfi_def_cfa_offset 0
+.endm
+
+.macro restore_7
+	# Tailcall into millicode.
+	j epilogue_7
+	.cfi_restore s7
+	.cfi_restore s6
+	.cfi_restore s5
+	.cfi_restore s4
+	.cfi_restore s3
+	.cfi_restore s2
+	.cfi_restore s1
+	.cfi_restore ra
+	.cfi_restore fp
+	.cfi_def_cfa_offset 0
+.endm
+
+.macro restore_8
+	# Tailcall into millicode.
+	j epilogue_8
+	.cfi_restore s8
+	.cfi_restore s7
+	.cfi_restore s6
+	.cfi_restore s5
+	.cfi_restore s4
+	.cfi_restore s3
+	.cfi_restore s2
+	.cfi_restore s1
+	.cfi_restore ra
+	.cfi_restore fp
+	.cfi_def_cfa_offset 0
+.endm
+
+.macro restore_9
+	# Tailcall into millicode.
+	j epilogue_9
+	.cfi_restore s9
+	.cfi_restore s8
+	.cfi_restore s7
+	.cfi_restore s6
+	.cfi_restore s5
+	.cfi_restore s4
+	.cfi_restore s3
+	.cfi_restore s2
+	.cfi_restore s1
+	.cfi_restore ra
+	.cfi_restore fp
+	.cfi_def_cfa_offset 0
+.endm
+
+.macro restore_10
+	# Tailcall into millicode.
+	j epilogue_10
+	.cfi_restore s10
+	.cfi_restore s9
+	.cfi_restore s8
+	.cfi_restore s7
+	.cfi_restore s6
+	.cfi_restore s5
+	.cfi_restore s4
+	.cfi_restore s3
+	.cfi_restore s2
+	.cfi_restore s1
+	.cfi_restore ra
+	.cfi_restore fp
+	.cfi_def_cfa_offset 0
+.endm
+
+.macro restore_11
+	# Tailcall into millicode.
+	j epilogue_11
+	.cfi_restore s11
+	.cfi_restore s10
+	.cfi_restore s9
+	.cfi_restore s8
+	.cfi_restore s7
+	.cfi_restore s6
+	.cfi_restore s5
+	.cfi_restore s4
+	.cfi_restore s3
+	.cfi_restore s2
+	.cfi_restore s1
+	.cfi_restore ra
+	.cfi_restore fp
+	.cfi_def_cfa_offset 0
+.endm
+

--- a/lib/millicode/frame_0.S
+++ b/lib/millicode/frame_0.S
@@ -1,0 +1,24 @@
+# ===========================================================================
+# Millicode for procedure prologue and epilogue (0 saved registers)
+# ===========================================================================
+
+.section .text
+
+#define FRAME_SIZE 0x10
+
+.global prologue_0
+prologue_0:
+	# Do NOT add CFI declarations. They go in macros.
+	addi sp, sp, -FRAME_SIZE
+	sd fp, 0x00(sp)
+	mv fp, sp
+	sd ra, 0x08(fp)
+	jr t0
+
+.global epilogue_0
+epilogue_0:
+	# Do NOT add CFI declarations. They go in macros.
+	ld ra, 0x08(fp)
+	ld fp, 0x00(fp)
+	addi sp, sp, FRAME_SIZE
+	ret

--- a/lib/millicode/frame_1.S
+++ b/lib/millicode/frame_1.S
@@ -1,0 +1,26 @@
+# ===========================================================================
+# Millicode for procedure prologue and epilogue (1 saved register)
+# ===========================================================================
+
+.section .text
+
+#define FRAME_SIZE 0x20
+
+.global prologue_1
+prologue_1:
+	# Do NOT add CFI declarations. They go in macros.
+	addi sp, sp, -FRAME_SIZE
+	sd fp, 0x00(sp)
+	mv fp, sp
+	sd ra, 0x08(fp)
+	sd s1, 0x10(fp)
+	jr t0
+
+.global epilogue_1
+epilogue_1:
+	# Do NOT add CFI declarations. They go in macros.
+	ld s1, 0x10(fp)
+	ld ra, 0x08(fp)
+	ld fp, 0x00(fp)
+	addi sp, sp, FRAME_SIZE
+	ret

--- a/lib/millicode/frame_10.S
+++ b/lib/millicode/frame_10.S
@@ -1,0 +1,44 @@
+# ===========================================================================
+# Millicode for procedure prologue and epilogue (10 saved registers)
+# ===========================================================================
+
+.section .text
+
+#define FRAME_SIZE 0x60
+
+.global prologue_10
+prologue_10:
+	# Do NOT add CFI declarations. They go in macros.
+	addi sp, sp, -FRAME_SIZE
+	sd fp, 0x00(sp)
+	mv fp, sp
+	sd ra, 0x08(fp)
+	sd s1, 0x10(fp)
+	sd s2, 0x18(fp)
+	sd s3, 0x20(fp)
+	sd s4, 0x28(fp)
+	sd s5, 0x30(fp)
+	sd s6, 0x38(fp)
+	sd s7, 0x40(fp)
+	sd s8, 0x48(fp)
+	sd s9, 0x50(fp)
+	sd s10, 0x58(fp)
+	jr t0
+
+.global epilogue_10
+epilogue_10:
+	# Do NOT add CFI declarations. They go in macros.
+	ld s10, 0x58(fp)
+	ld s9, 0x50(fp)
+	ld s8, 0x48(fp)
+	ld s7, 0x40(fp)
+	ld s6, 0x38(fp)
+	ld s5, 0x30(fp)
+	ld s4, 0x28(fp)
+	ld s3, 0x20(fp)
+	ld s2, 0x18(fp)
+	ld s1, 0x10(fp)
+	ld ra, 0x08(fp)
+	ld fp, 0x00(fp)
+	addi sp, sp, FRAME_SIZE
+	ret

--- a/lib/millicode/frame_11.S
+++ b/lib/millicode/frame_11.S
@@ -1,0 +1,46 @@
+# ===========================================================================
+# Millicode for procedure prologue and epilogue (11 saved registers)
+# ===========================================================================
+
+.section .text
+
+#define FRAME_SIZE 0x70
+
+.global prologue_11
+prologue_11:
+	# Do NOT add CFI declarations. They go in macros.
+	addi sp, sp, -FRAME_SIZE
+	sd fp, 0x00(sp)
+	mv fp, sp
+	sd ra, 0x08(fp)
+	sd s1, 0x10(fp)
+	sd s2, 0x18(fp)
+	sd s3, 0x20(fp)
+	sd s4, 0x28(fp)
+	sd s5, 0x30(fp)
+	sd s6, 0x38(fp)
+	sd s7, 0x40(fp)
+	sd s8, 0x48(fp)
+	sd s9, 0x50(fp)
+	sd s10, 0x58(fp)
+	sd s11, 0x60(fp)
+	jr t0
+
+.global epilogue_11
+epilogue_11:
+	# Do NOT add CFI declarations. They go in macros.
+	ld s11, 0x60(fp)
+	ld s10, 0x58(fp)
+	ld s9, 0x50(fp)
+	ld s8, 0x48(fp)
+	ld s7, 0x40(fp)
+	ld s6, 0x38(fp)
+	ld s5, 0x30(fp)
+	ld s4, 0x28(fp)
+	ld s3, 0x20(fp)
+	ld s2, 0x18(fp)
+	ld s1, 0x10(fp)
+	ld ra, 0x08(fp)
+	ld fp, 0x00(fp)
+	addi sp, sp, FRAME_SIZE
+	ret

--- a/lib/millicode/frame_2.S
+++ b/lib/millicode/frame_2.S
@@ -1,0 +1,28 @@
+# ===========================================================================
+# Millicode for procedure prologue and epilogue (2 saved registers)
+# ===========================================================================
+
+.section .text
+
+#define FRAME_SIZE 0x20
+
+.global prologue_2
+prologue_2:
+	# Do NOT add CFI declarations. They go in macros.
+	addi sp, sp, -FRAME_SIZE
+	sd fp, 0x00(sp)
+	mv fp, sp
+	sd ra, 0x08(fp)
+	sd s1, 0x10(fp)
+	sd s2, 0x18(fp)
+	jr t0
+
+.global epilogue_2
+epilogue_2:
+	# Do NOT add CFI declarations. They go in macros.
+	ld s2, 0x18(fp)
+	ld s1, 0x10(fp)
+	ld ra, 0x08(fp)
+	ld fp, 0x00(fp)
+	addi sp, sp, FRAME_SIZE
+	ret

--- a/lib/millicode/frame_3.S
+++ b/lib/millicode/frame_3.S
@@ -1,0 +1,30 @@
+# ===========================================================================
+# Millicode for procedure prologue and epilogue (3 saved registers)
+# ===========================================================================
+
+.section .text
+
+#define FRAME_SIZE 0x30
+
+.global prologue_3
+prologue_3:
+	# Do NOT add CFI declarations. They go in macros.
+	addi sp, sp, -FRAME_SIZE
+	sd fp, 0x00(sp)
+	mv fp, sp
+	sd ra, 0x08(fp)
+	sd s1, 0x10(fp)
+	sd s2, 0x18(fp)
+	sd s3, 0x20(fp)
+	jr t0
+
+.global epilogue_3
+epilogue_3:
+	# Do NOT add CFI declarations. They go in macros.
+	ld s3, 0x20(fp)
+	ld s2, 0x18(fp)
+	ld s1, 0x10(fp)
+	ld ra, 0x08(fp)
+	ld fp, 0x00(fp)
+	addi sp, sp, FRAME_SIZE
+	ret

--- a/lib/millicode/frame_4.S
+++ b/lib/millicode/frame_4.S
@@ -1,0 +1,32 @@
+# ===========================================================================
+# Millicode for procedure prologue and epilogue (4 saved registers)
+# ===========================================================================
+
+.section .text
+
+#define FRAME_SIZE 0x30
+
+.global prologue_4
+prologue_4:
+	# Do NOT add CFI declarations. They go in macros.
+	addi sp, sp, -FRAME_SIZE
+	sd fp, 0x00(sp)
+	mv fp, sp
+	sd ra, 0x08(fp)
+	sd s1, 0x10(fp)
+	sd s2, 0x18(fp)
+	sd s3, 0x20(fp)
+	sd s4, 0x28(fp)
+	jr t0
+
+.global epilogue_4
+epilogue_4:
+	# Do NOT add CFI declarations. They go in macros.
+	ld s4, 0x28(fp)
+	ld s3, 0x20(fp)
+	ld s2, 0x18(fp)
+	ld s1, 0x10(fp)
+	ld ra, 0x08(fp)
+	ld fp, 0x00(fp)
+	addi sp, sp, FRAME_SIZE
+	ret

--- a/lib/millicode/frame_5.S
+++ b/lib/millicode/frame_5.S
@@ -1,0 +1,34 @@
+# ===========================================================================
+# Millicode for procedure prologue and epilogue (5 saved registers)
+# ===========================================================================
+
+.section .text
+
+#define FRAME_SIZE 0x40
+
+.global prologue_5
+prologue_5:
+	# Do NOT add CFI declarations. They go in macros.
+	addi sp, sp, -FRAME_SIZE
+	sd fp, 0x00(sp)
+	mv fp, sp
+	sd ra, 0x08(fp)
+	sd s1, 0x10(fp)
+	sd s2, 0x18(fp)
+	sd s3, 0x20(fp)
+	sd s4, 0x28(fp)
+	sd s5, 0x30(fp)
+	jr t0
+
+.global epilogue_5
+epilogue_5:
+	# Do NOT add CFI declarations. They go in macros.
+	ld s5, 0x30(fp)
+	ld s4, 0x28(fp)
+	ld s3, 0x20(fp)
+	ld s2, 0x18(fp)
+	ld s1, 0x10(fp)
+	ld ra, 0x08(fp)
+	ld fp, 0x00(fp)
+	addi sp, sp, FRAME_SIZE
+	ret

--- a/lib/millicode/frame_6.S
+++ b/lib/millicode/frame_6.S
@@ -1,0 +1,36 @@
+# ===========================================================================
+# Millicode for procedure prologue and epilogue (6 saved registers)
+# ===========================================================================
+
+.section .text
+
+#define FRAME_SIZE 0x40
+
+.global prologue_6
+prologue_6:
+	# Do NOT add CFI declarations. They go in macros.
+	addi sp, sp, -FRAME_SIZE
+	sd fp, 0x00(sp)
+	mv fp, sp
+	sd ra, 0x08(fp)
+	sd s1, 0x10(fp)
+	sd s2, 0x18(fp)
+	sd s3, 0x20(fp)
+	sd s4, 0x28(fp)
+	sd s5, 0x30(fp)
+	sd s6, 0x38(fp)
+	jr t0
+
+.global epilogue_6
+epilogue_6:
+	# Do NOT add CFI declarations. They go in macros.
+	ld s6, 0x38(fp)
+	ld s5, 0x30(fp)
+	ld s4, 0x28(fp)
+	ld s3, 0x20(fp)
+	ld s2, 0x18(fp)
+	ld s1, 0x10(fp)
+	ld ra, 0x08(fp)
+	ld fp, 0x00(fp)
+	addi sp, sp, FRAME_SIZE
+	ret

--- a/lib/millicode/frame_7.S
+++ b/lib/millicode/frame_7.S
@@ -1,0 +1,38 @@
+# ===========================================================================
+# Millicode for procedure prologue and epilogue (7 saved registers)
+# ===========================================================================
+
+.section .text
+
+#define FRAME_SIZE 0x50
+
+.global prologue_7
+prologue_7:
+	# Do NOT add CFI declarations. They go in macros.
+	addi sp, sp, -FRAME_SIZE
+	sd fp, 0x00(sp)
+	mv fp, sp
+	sd ra, 0x08(fp)
+	sd s1, 0x10(fp)
+	sd s2, 0x18(fp)
+	sd s3, 0x20(fp)
+	sd s4, 0x28(fp)
+	sd s5, 0x30(fp)
+	sd s6, 0x38(fp)
+	sd s7, 0x40(fp)
+	jr t0
+
+.global epilogue_7
+epilogue_7:
+	# Do NOT add CFI declarations. They go in macros.
+	ld s7, 0x40(fp)
+	ld s6, 0x38(fp)
+	ld s5, 0x30(fp)
+	ld s4, 0x28(fp)
+	ld s3, 0x20(fp)
+	ld s2, 0x18(fp)
+	ld s1, 0x10(fp)
+	ld ra, 0x08(fp)
+	ld fp, 0x00(fp)
+	addi sp, sp, FRAME_SIZE
+	ret

--- a/lib/millicode/frame_8.S
+++ b/lib/millicode/frame_8.S
@@ -1,0 +1,40 @@
+# ===========================================================================
+# Millicode for procedure prologue and epilogue (8 saved registers)
+# ===========================================================================
+
+.section .text
+
+#define FRAME_SIZE 0x50
+
+.global prologue_8
+prologue_8:
+	# Do NOT add CFI declarations. They go in macros.
+	addi sp, sp, -FRAME_SIZE
+	sd fp, 0x00(sp)
+	mv fp, sp
+	sd ra, 0x08(fp)
+	sd s1, 0x10(fp)
+	sd s2, 0x18(fp)
+	sd s3, 0x20(fp)
+	sd s4, 0x28(fp)
+	sd s5, 0x30(fp)
+	sd s6, 0x38(fp)
+	sd s7, 0x40(fp)
+	sd s8, 0x48(fp)
+	jr t0
+
+.global epilogue_8
+epilogue_8:
+	# Do NOT add CFI declarations. They go in macros.
+	ld s8, 0x48(fp)
+	ld s7, 0x40(fp)
+	ld s6, 0x38(fp)
+	ld s5, 0x30(fp)
+	ld s4, 0x28(fp)
+	ld s3, 0x20(fp)
+	ld s2, 0x18(fp)
+	ld s1, 0x10(fp)
+	ld ra, 0x08(fp)
+	ld fp, 0x00(fp)
+	addi sp, sp, FRAME_SIZE
+	ret

--- a/lib/millicode/frame_9.S
+++ b/lib/millicode/frame_9.S
@@ -1,0 +1,42 @@
+# ===========================================================================
+# Millicode for procedure prologue and epilogue (9 saved registers)
+# ===========================================================================
+
+.section .text
+
+#define FRAME_SIZE 0x60
+
+.global prologue_9
+prologue_9:
+	# Do NOT add CFI declarations. They go in macros.
+	addi sp, sp, -FRAME_SIZE
+	sd fp, 0x00(sp)
+	mv fp, sp
+	sd ra, 0x08(fp)
+	sd s1, 0x10(fp)
+	sd s2, 0x18(fp)
+	sd s3, 0x20(fp)
+	sd s4, 0x28(fp)
+	sd s5, 0x30(fp)
+	sd s6, 0x38(fp)
+	sd s7, 0x40(fp)
+	sd s8, 0x48(fp)
+	sd s9, 0x50(fp)
+	jr t0
+
+.global epilogue_9
+epilogue_9:
+	# Do NOT add CFI declarations. They go in macros.
+	ld s9, 0x50(fp)
+	ld s8, 0x48(fp)
+	ld s7, 0x40(fp)
+	ld s6, 0x38(fp)
+	ld s5, 0x30(fp)
+	ld s4, 0x28(fp)
+	ld s3, 0x20(fp)
+	ld s2, 0x18(fp)
+	ld s1, 0x10(fp)
+	ld ra, 0x08(fp)
+	ld fp, 0x00(fp)
+	addi sp, sp, FRAME_SIZE
+	ret

--- a/make
+++ b/make
@@ -85,7 +85,10 @@ build_executable() {
 	target_dir="$(dirname "$target")"
 	mkdir -p "$target_dir"
 
-	"$AS" $ASFLAGS -o "$target" "$@" "$BUILD_ROOT/lib/libentrypoint.a"
+	"$AS" $ASFLAGS -o "$target" \
+		"$@" \
+		"$BUILD_ROOT/lib/libentrypoint.a" \
+		"$BUILD_ROOT/lib/libmillicode.a"
 }
 
 with_test() {
@@ -103,7 +106,8 @@ with_test() {
 		"$source" \
 		"$@" \
 		"$BUILD_ROOT/lib/libtesting.a" \
-		"$BUILD_ROOT/lib/libentrypoint.a"
+		"$BUILD_ROOT/lib/libentrypoint.a" \
+		"$BUILD_ROOT/lib/libmillicode.a"
 
 	# Run test.
 	info "Running test $target..."
@@ -127,27 +131,55 @@ sanity_check() {
 
 clean
 
-# Build the core library.
+# Build the millicode library.
+assemble lib/millicode/frame_0.S
+assemble lib/millicode/frame_1.S
+assemble lib/millicode/frame_2.S
+assemble lib/millicode/frame_3.S
+assemble lib/millicode/frame_4.S
+assemble lib/millicode/frame_5.S
+assemble lib/millicode/frame_6.S
+assemble lib/millicode/frame_7.S
+assemble lib/millicode/frame_8.S
+assemble lib/millicode/frame_9.S
+assemble lib/millicode/frame_10.S
+assemble lib/millicode/frame_11.S
+
+build_library lib/libmillicode.a \
+	"$BUILD_ROOT/lib/millicode/frame_0.o" \
+	"$BUILD_ROOT/lib/millicode/frame_1.o" \
+	"$BUILD_ROOT/lib/millicode/frame_2.o" \
+	"$BUILD_ROOT/lib/millicode/frame_3.o" \
+	"$BUILD_ROOT/lib/millicode/frame_4.o" \
+	"$BUILD_ROOT/lib/millicode/frame_5.o" \
+	"$BUILD_ROOT/lib/millicode/frame_6.o" \
+	"$BUILD_ROOT/lib/millicode/frame_7.o" \
+	"$BUILD_ROOT/lib/millicode/frame_8.o" \
+	"$BUILD_ROOT/lib/millicode/frame_9.o" \
+	"$BUILD_ROOT/lib/millicode/frame_10.o" \
+	"$BUILD_ROOT/lib/millicode/frame_11.o"
+
+# Build the entrypoint library.
 assemble lib/entrypoint/entrypoint.S
 
 build_library lib/libentrypoint.a \
 	"$BUILD_ROOT/lib/entrypoint/entrypoint.o"
 
+# Build a simple program that uses libentrypoint and terminates successfully.
+assemble cmd/true/true.S
+
+build_executable cmd/true/true \
+	"$BUILD_ROOT/cmd/true/true.o"
+
+sanity_check "$BUILD_ROOT/cmd/true/true"
+
+# Build the core library.
 assemble lib/p0/io.S
 assemble lib/p0/os.S
 
 build_library lib/libp0.a \
 	"$BUILD_ROOT/lib/p0/io.o" \
 	"$BUILD_ROOT/lib/p0/os.o"
-
-# Build a simple program that uses libentrypoint and terminates successfully.
-assemble cmd/true/true.S
-
-build_executable cmd/true/true \
-	"$BUILD_ROOT/cmd/true/true.o" \
-	"$BUILD_ROOT/lib/libp0.a"
-
-sanity_check "$BUILD_ROOT/cmd/true/true"
 
 # Build a simple program that uses libp0 and terminates successfully.
 assemble cmd/hello/hello.S


### PR DESCRIPTION
Added macros and procedures to handle common stack frame management
needs. This reduces both boilerplate and code size. While the latter
might look less important, it does reduce the amount of noise in a
debugger window, at least.