### PR TITLE
Improve testing

### DIFF
--- a/cmd/hello/hello.S
+++ b/cmd/hello/hello.S
@@ -4,9 +4,9 @@
 # A classic. Also useful to check that basic IO and safe_str work.
 # ===========================================================================
 
-.include "inc/millicode.S"
-.include "inc/io.S"
-.include "inc/safe_str.S"
+#include "millicode.S"
+#include "io.S"
+#include "safe_str.S"
 
 .section .rodata
 

--- a/inc/testing.S
+++ b/inc/testing.S
@@ -1,11 +1,12 @@
 # ===========================================================================
 # Testing macros
 #
-# Note that the register s1 is reserved to store `failed` and the register
+# Note that the register s11 is reserved to store `failed` and the register
 # `t6` will be used to implement assertions.
 # ===========================================================================
 
-#define failed s1
+# Abuse the thread pointer, since p0 is single threaded.
+#define failed tp
 
 # ===========================================================================
 # Test case macros
@@ -66,22 +67,33 @@ main:
 # ===========================================================================
 
 .macro expect_eq expected, actual
-	addi t6, \actual, -\expected
-	or s1, s1, t6
+	sub t6, \expected, \actual
+	or failed, failed, t6
 .endm
 
 .macro expect_ne forbidden, actual
+	sub t6, \forbidden, \actual
+	seqz t6, t6
+	or failed, failed, t6
+.endm
+
+.macro expect_eqi expected, actual
+	addi t6, \actual, -\expected
+	or failed, failed, t6
+.endm
+
+.macro expect_nei forbidden, actual
 	addi t6, \actual, -\forbidden
 	seqz t6, t6
-	or s1, s1, t6
+	or failed, failed, t6
 .endm
 
 .macro expect_z actual
-	or s1, s1, \actual
+	or failed, failed, \actual
 .endm
 
 .macro expect_nz actual
 	seqz t6, \actual
-	or s1, s1, t6
+	or failed, failed, t6
 .endm
 

--- a/lib/entrypoint/entrypoint.S
+++ b/lib/entrypoint/entrypoint.S
@@ -2,7 +2,7 @@
 # Entrypoint for executables
 # ===========================================================================
 
-.include "inc/syscall.S"
+#include "syscall.S"
 
 .section .text
 

--- a/lib/p0/io/write.S
+++ b/lib/p0/io/write.S
@@ -2,7 +2,7 @@
 # Basic I/O functionality
 # ===========================================================================
 
-.include "inc/syscall.S"
+#include "syscall.S"
 
 .section .text
 

--- a/lib/p0/io/write_test.S
+++ b/lib/p0/io/write_test.S
@@ -2,9 +2,9 @@
 # write tests
 # ===========================================================================
 
-.include "inc/millicode.S"
-.include "inc/safe_str.S"
-.include "inc/testing.S"
+#include "millicode.S"
+#include "safe_str.S"
+#include "testing.S"
 
 
 # ===========================================================================
@@ -32,7 +32,7 @@ test_case write_ok
 	li a2, msg_size
 	call "io.Write"
 
-	expect_eq msg_size, a0
+	expect_eqi msg_size, a0
 	expect_z a1
 
 	restore_0

--- a/lib/p0/os/exit.S
+++ b/lib/p0/os/exit.S
@@ -4,7 +4,7 @@
 
 .section .text
 
-.include "inc/syscall.S"
+#include "syscall.S"
 
 # Terminates the application. This function does NOT return.
 #

--- a/lib/testing/testing.S
+++ b/lib/testing/testing.S
@@ -11,8 +11,12 @@
 # that it is testing, we have written it with no external dependencies.
 # ===========================================================================
 
-.include "inc/millicode.S"
-.include "inc/safe_str.S"
+#include "millicode.S"
+#include "safe_str.S"
+
+# Must be kept in sync with "inc/testing.S"
+# Abuse the thread pointer, since p0 is single threaded.
+#define failed tp
 
 # Standard IO.
 .equiv STDIN,  0
@@ -53,7 +57,7 @@ safe_str fail_msg, "[TEST: FAIL]\n\n"
 .global run_test
 run_test:
 	# Callee-saved registers.
-	#define failed         s1
+	#define failed_backup  s1
 	#define test_fn        s2
 	#define test_name      s3
 	#define test_name_size s4
@@ -64,6 +68,7 @@ run_test:
 
 	.cfi_startproc
 	save_4
+	mv failed_backup, failed
 
 	# Preserve arguments and initialise saved variables.
 	li failed, 0
@@ -92,6 +97,9 @@ run_test:
 	li a7, SYSCALL_WRITE
 	ecall
 
+	# Clear the failures.
+	li failed, 0
+
 	# Run the test case.
 	jalr test_fn
 
@@ -99,8 +107,8 @@ run_test:
 	# Accumulate and save the test status.
 	la failed_ptr, "testing.failed"
 	ld failed_previously, 0(failed_ptr)
-	or failed, failed, failed_previously
-	sd failed, 0(failed_ptr)
+	or failed_previously, failed, failed_previously
+	sd failed_previously, 0(failed_ptr)
 
 	# Check if the test passed.
 	bnez failed, .Lfail

--- a/make
+++ b/make
@@ -20,7 +20,7 @@ fi
 
 # Apply defaults.
 AS="${AS:-riscv64-unknown-elf-gcc}"
-ASFLAGS="${ASFLAGS:--ggdb3 -mcmodel=medlow -nostdlib -static}"
+ASFLAGS="${ASFLAGS:--ggdb3 -Iinc -mcmodel=medlow -nostdlib -static}"
 BUILD_ROOT="${BUILD_ROOT:-build}"
 
 # ===========================================================================
@@ -180,12 +180,12 @@ build_library lib/libtesting.a \
 	"$BUILD_ROOT/lib/testing/testing.o"
 
 # Build the core library.
-assemble lib/p0/io/write.S
 assemble lib/p0/os/exit.S
+assemble lib/p0/io/write.S
 
 build_library lib/libp0.a \
-	"$BUILD_ROOT/lib/p0/io/write.o" \
-	"$BUILD_ROOT/lib/p0/os/exit.o"
+	"$BUILD_ROOT/lib/p0/os/exit.o" \
+	"$BUILD_ROOT/lib/p0/io/write.o"
 
 # Test the core library.
 with_test lib/p0/io/write_test \


### PR DESCRIPTION
* Use #include instead of .include so that #defines work.

  * Abuse the tp (thread pointer) register as a "test register".

  * Improve the "expect_*" functions.