### PR TITLE
rename sN strings to strN

### DIFF
--- a/lib/p0/mem/eq_test.S
+++ b/lib/p0/mem/eq_test.S
@@ -47,19 +47,19 @@ nil:
 
 .section .rodata
 
-safe_str s0, ""
-safe_str s1, "a"
-safe_str s2, "ab"
-safe_str s3, "abc"
+safe_str str0, ""
+safe_str str1, "a"
+safe_str str2, "ab"
+safe_str str3, "abc"
 
-safe_str copy_s0, ""
-safe_str copy_s1, "a"
-safe_str copy_s2, "ab"
-safe_str copy_s3, "abc"
+safe_str copy_str0, ""
+safe_str copy_str1, "a"
+safe_str copy_str2, "ab"
+safe_str copy_str3, "abc"
 
-safe_str other_s1, "x"
-safe_str other_s2, "xy"
-safe_str other_s3, "xyz"
+safe_str other_str1, "x"
+safe_str other_str2, "xy"
+safe_str other_str3, "xyz"
 
 safe_str different_but_same_prefix_2, "ay"
 safe_str different_but_same_prefix_3, "abz"
@@ -74,22 +74,22 @@ safe_str different_but_same_prefix_3, "abz"
 accept nil, nil
 
 # Identical slices.
-accept s0, s0
-accept s1, s1
-accept s2, s2
-accept s3, s3
+accept str0, str0
+accept str1, str1
+accept str2, str2
+accept str3, str3
 
 # Equal but not identical slices.
-accept s0, copy_s0
-accept s1, copy_s1
-accept s2, copy_s2
-accept s3, copy_s3
+accept str0, copy_str0
+accept str1, copy_str1
+accept str2, copy_str2
+accept str3, copy_str3
 
 # Different slices.
-reject s1, other_s1
-reject s2, other_s2
-reject s3, other_s3
+reject str1, other_str1
+reject str2, other_str2
+reject str3, other_str3
 
 # Different slices with a shared prefix.
-reject s2, different_but_same_prefix_2
-reject s3, different_but_same_prefix_3
+reject str2, different_but_same_prefix_2
+reject str3, different_but_same_prefix_3

--- a/lib/p0/mem/index_test.S
+++ b/lib/p0/mem/index_test.S
@@ -55,45 +55,45 @@ nil:
 
 .section .rodata
 
-safe_str s0, ""
-safe_str s1, "a"
-safe_str s2, "ab"
-safe_str s3, "abc"
+safe_str str0, ""
+safe_str str1, "a"
+safe_str str2, "ab"
+safe_str str3, "abc"
 
-safe_str s0_copy, ""
-safe_str s1_copy, "a"
-safe_str s2_copy, "ab"
-safe_str s3_copy, "abc"
+safe_str str0_copy, ""
+safe_str str1_copy, "a"
+safe_str str2_copy, "ab"
+safe_str str3_copy, "abc"
 
-safe_str other_s1, "x"
-safe_str other_s2, "xy"
-safe_str other_s3, "xyz"
+safe_str other_str1, "x"
+safe_str other_str2, "xy"
+safe_str other_str3, "xyz"
 
 safe_str different_but_same_prefix_2, "ay"
 safe_str different_but_same_prefix_3, "abz"
 
-only_s0:
-safe_str_slice s0
-.equiv only_s0_size, 1
+only_str0:
+safe_str_slice str0
+.equiv only_str0_size, 1
 
-only_s1:
-safe_str_slice s1
-.equiv only_s1_size, 1
+only_str1:
+safe_str_slice str1
+.equiv only_str1_size, 1
 
-only_s2:
-safe_str_slice s2
-.equiv only_s2_size, 1
+only_str2:
+safe_str_slice str2
+.equiv only_str2_size, 1
 
-only_s3:
-safe_str_slice s3
-.equiv only_s3_size, 1
+only_str3:
+safe_str_slice str3
+.equiv only_str3_size, 1
 
 empty_slice:
 .equiv empty_slice_size, 0
 
 three_strings:
-safe_str_slice s3
-safe_str_slice other_s3
+safe_str_slice str3
+safe_str_slice other_str3
 safe_str_slice different_but_same_prefix_2
 .equiv three_strings_size, 3
 
@@ -106,72 +106,72 @@ safe_str_slice different_but_same_prefix_2
 
 not_found nil, nil
 
-not_found s0, nil
-not_found s1, nil
-not_found s2, nil
-not_found s3, nil
+not_found str0, nil
+not_found str1, nil
+not_found str2, nil
+not_found str3, nil
 
-not_found s0_copy, nil
-not_found s1_copy, nil
-not_found s2_copy, nil
-not_found s3_copy, nil
+not_found str0_copy, nil
+not_found str1_copy, nil
+not_found str2_copy, nil
+not_found str3_copy, nil
 
-not_found s0, empty_slice
-not_found s1, empty_slice
-not_found s2, empty_slice
-not_found s3, empty_slice
+not_found str0, empty_slice
+not_found str1, empty_slice
+not_found str2, empty_slice
+not_found str3, empty_slice
 
-not_found s0_copy, empty_slice
-not_found s1_copy, empty_slice
-not_found s2_copy, empty_slice
-not_found s3_copy, empty_slice
+not_found str0_copy, empty_slice
+not_found str1_copy, empty_slice
+not_found str2_copy, empty_slice
+not_found str3_copy, empty_slice
 
-found s0, only_s0, 0
-not_found s1, only_s0
-not_found s2, only_s0
-not_found s3, only_s0
+found str0, only_str0, 0
+not_found str1, only_str0
+not_found str2, only_str0
+not_found str3, only_str0
 
-found s0_copy, only_s0, 0
-not_found s1_copy, only_s0
-not_found s2_copy, only_s0
-not_found s3_copy, only_s0
+found str0_copy, only_str0, 0
+not_found str1_copy, only_str0
+not_found str2_copy, only_str0
+not_found str3_copy, only_str0
 
-found s1, only_s1, 0
-not_found s0, only_s1
-not_found s2, only_s1
-not_found s3, only_s1
+found str1, only_str1, 0
+not_found str0, only_str1
+not_found str2, only_str1
+not_found str3, only_str1
 
-found s1_copy, only_s1, 0
-not_found s0_copy, only_s1
-not_found s2_copy, only_s1
-not_found s3_copy, only_s1
+found str1_copy, only_str1, 0
+not_found str0_copy, only_str1
+not_found str2_copy, only_str1
+not_found str3_copy, only_str1
 
-found s2, only_s2, 0
-not_found s0, only_s2
-not_found s1, only_s2
-not_found s3, only_s2
+found str2, only_str2, 0
+not_found str0, only_str2
+not_found str1, only_str2
+not_found str3, only_str2
 
-found s2_copy, only_s2, 0
-not_found s0_copy, only_s2
-not_found s1_copy, only_s2
-not_found s3_copy, only_s2
+found str2_copy, only_str2, 0
+not_found str0_copy, only_str2
+not_found str1_copy, only_str2
+not_found str3_copy, only_str2
 
-found s3, only_s3, 0
-not_found s0, only_s3
-not_found s1, only_s3
-not_found s2, only_s3
+found str3, only_str3, 0
+not_found str0, only_str3
+not_found str1, only_str3
+not_found str2, only_str3
 
-found s3_copy, only_s3, 0
-not_found s0_copy, only_s3
-not_found s1_copy, only_s3
-not_found s2_copy, only_s3
+found str3_copy, only_str3, 0
+not_found str0_copy, only_str3
+not_found str1_copy, only_str3
+not_found str2_copy, only_str3
 
-found s3_copy, three_strings, 0
-not_found s0_copy, three_strings
-not_found s1_copy, three_strings
-not_found s2_copy, three_strings
+found str3_copy, three_strings, 0
+not_found str0_copy, three_strings
+not_found str1_copy, three_strings
+not_found str2_copy, three_strings
 
-found s3, three_strings, 0
-found other_s3, three_strings, 1
+found str3, three_strings, 0
+found other_str3, three_strings, 1
 found different_but_same_prefix_2, three_strings, 2
 not_found different_but_same_prefix_3, three_strings

--- a/lib/p0/mem/shortlex_test.S
+++ b/lib/p0/mem/shortlex_test.S
@@ -14,13 +14,13 @@
 .macro expect_equal x, y
 test_case Shortlex_\x\()_and_\y\()_return_equal
 	save_0
-	
+
 	la a0, \x
 	li a1, \x\()_size
 	la a2, \y
 	li a3, \y\()_size
 	call "mem/Shortlex"
-	
+
 	expect_z a0
 
 	restore_0
@@ -30,13 +30,13 @@ end_test
 .macro expect_smaller x, y
 test_case Shortlex_\x\()_and_\y\()_return_smaller
 	save_0
-	
+
 	la a0, \x
 	li a1, \x\()_size
 	la a2, \y
 	li a3, \y\()_size
 	call "mem/Shortlex"
-	
+
 	expect_negative a0
 
 	restore_0
@@ -46,13 +46,13 @@ end_test
 .macro expect_bigger x, y
 test_case Shortlex_\x\()_and_\y\()_return_bigger
 	save_0
-	
+
 	la a0, \x
 	li a1, \x\()_size
 	la a2, \y
 	li a3, \y\()_size
 	call "mem/Shortlex"
-	
+
 	expect_positive a0
 
 	restore_0
@@ -70,19 +70,19 @@ nil:
 
 .section .rodata
 
-safe_str s0, ""
-safe_str s1, "a"
-safe_str s2, "ab"
-safe_str s3, "abc"
+safe_str str0, ""
+safe_str str1, "a"
+safe_str str2, "ab"
+safe_str str3, "abc"
 
-safe_str s0_copy, ""
-safe_str s1_copy, "a"
-safe_str s2_copy, "ab"
-safe_str s3_copy, "abc"
+safe_str str0_copy, ""
+safe_str str1_copy, "a"
+safe_str str2_copy, "ab"
+safe_str str3_copy, "abc"
 
-safe_str other_s1, "x"
-safe_str other_s2, "xy"
-safe_str other_s3, "xyz"
+safe_str other_str1, "x"
+safe_str other_str2, "xy"
+safe_str other_str3, "xyz"
 
 safe_str different_but_same_prefix_2, "ay"
 safe_str different_but_same_prefix_3, "abz"
@@ -97,37 +97,37 @@ safe_str different_but_same_prefix_3, "abz"
 expect_equal nil, nil
 
 # Identical slices.
-expect_equal s0, s0
-expect_equal s1, s1
-expect_equal s2, s2
-expect_equal s3, s3
+expect_equal str0, str0
+expect_equal str1, str1
+expect_equal str2, str2
+expect_equal str3, str3
 
 # Equal but not identical slices.
-expect_equal s0, s0_copy
-expect_equal s1, s1_copy
-expect_equal s2, s2_copy
-expect_equal s3, s3_copy
+expect_equal str0, str0_copy
+expect_equal str1, str1_copy
+expect_equal str2, str2_copy
+expect_equal str3, str3_copy
 
 # Different slices of the same size, returning smaller.
-expect_smaller s1, other_s1
-expect_smaller s2, other_s2
-expect_smaller s3, other_s3
+expect_smaller str1, other_str1
+expect_smaller str2, other_str2
+expect_smaller str3, other_str3
 
 # Different slices of the same size, returning bigger.
-expect_bigger other_s1, s1
-expect_bigger other_s2, s2
-expect_bigger other_s3, s3
+expect_bigger other_str1, str1
+expect_bigger other_str2, str2
+expect_bigger other_str3, str3
 
 # Different but with a common prefix.
-expect_smaller s2, different_but_same_prefix_2
-expect_bigger different_but_same_prefix_2, s2
+expect_smaller str2, different_but_same_prefix_2
+expect_bigger different_but_same_prefix_2, str2
 
-expect_smaller s3, different_but_same_prefix_3
-expect_bigger different_but_same_prefix_3, s3
+expect_smaller str3, different_but_same_prefix_3
+expect_bigger different_but_same_prefix_3, str3
 
 # The size decides against the lexicographical order.
-expect_smaller other_s1, s2
-expect_bigger s2, other_s1
+expect_smaller other_str1, str2
+expect_bigger str2, other_str1
 
-expect_smaller other_s2, s3
-expect_bigger s3, other_s2
+expect_smaller other_str2, str3
+expect_bigger str3, other_str2


### PR DESCRIPTION
Avoids ambiguity with saved registers on RISC-V.