### PR TITLE
p0/strintern: add package

### DIFF
--- a/lib/p0/strintern/strintern.S
+++ b/lib/p0/strintern/strintern.S
@@ -1,0 +1,330 @@
+# ===========================================================================
+# String interning
+# ===========================================================================
+
+# Design
+#
+# String interning reduces string comparison to pointer comparison, which is
+# both simpler and faster than comparing the memory contents.
+#
+# The design of this data structure is tailored to the compiler needs:
+#
+#   - String comparison is frequent and should be made as simple as possible.
+#     Therefore, rather than comparing the slice (pointer and size), it
+#     clones the string value to ensure that it cannot be aliased by any
+#     other interned string. As a result, it is sufficient to compare the
+#     pointer, which reduces comparison to a single BEQ/BNE instruction.
+#
+#   - Despite the above, we return the full slice as a value rather than a
+#     handle. This eliminates the need to implement a mechanism to resolve
+#     handles into strings and simplifies debugging because the string is
+#     trivial to resolve.
+#
+#   - Memory is allocated, but never freed. Therefore, we can rely on the
+#     `forever` allocator for simplicity, and obviate removal operations.
+#
+#   - Sublinear operation cost is not necessary, but it is desirable.
+#     We have chosen AA trees because they are very easy to implement but
+#     guarantee good asymptotic behaviour.
+#
+#   - It only needs to support reasonable identifiers. In particular, this
+#     means that it does not need to support extremely long strings. We
+#     exploit this to reduce the size of the AA node size without resorting
+#     to tricks like packing the colour in the LSB of the pointers.
+#
+#   - It uses shortlex to compare strings. It's faster than dictionary order,
+#     and the ordering itself doesn't matter, as long as there's one.
+
+#include <millicode.S>
+
+
+# Tree node.
+.struct 0
+"strintern.node":
+"strintern.node.left":      .space 8
+"strintern.node.right":     .space 8
+"strintern.node.level":     .space 4
+"strintern.node.str_size":  .space 4
+"strintern.node.str_data":  .space 8
+.equiv "strintern.node_size", . - "strintern.node"
+
+
+# ===========================================================================
+# Constants
+# ===========================================================================
+
+.section .rodata
+
+# Type: TreeNode
+#
+# The sentinel node has level 0, so no extra work is necessary to encode it.
+.align 4
+"strintern.sentinel":
+.8byte "strintern.sentinel" # left
+.8byte "strintern.sentinel" # right
+.4byte 0 # level
+.4byte 0 # str_size
+.8byte 0 # str_data
+.equiv "strintern.sentinel_size", . - "strintern.sentinel"
+
+
+# ===========================================================================
+# Global variables
+# ===========================================================================
+
+.section .data
+
+# Stores a pointer to the tree root.
+"strintern.root":
+.8byte "strintern.sentinel"
+
+
+# ===========================================================================
+# Public interface
+# ===========================================================================
+
+.section .text
+
+# Intern a string.
+#
+# Inputs:
+#   a0: pointer to string data
+#   a1: size of string
+#
+# Outputs:
+#   a0: pointer to interned string data
+#   a1: size of string
+.global "strintern.Intern"
+"strintern.Intern":
+	#define sentinel_backup s1
+	#define root_ptr        s2
+
+	# Shared registers.
+	#define sentinel        s11
+
+	.cfi_startproc
+	save_2
+	mv sentinel_backup, sentinel
+
+	la sentinel, "strintern.sentinel"
+	la root_ptr, "strintern.root"
+
+	# a0-1 already have the values.
+	ld a2, 0(root_ptr)
+	call "strintern.findOrInsert"
+
+	# The root pointer may have been modified.
+	sd a2, 0(root_ptr)
+
+	mv sentinel, sentinel_backup
+	restore_2
+	.cfi_endproc
+
+	#undefine sentinel_backup
+	#undefine root_ptr
+
+
+# ===========================================================================
+# Private functions
+# ===========================================================================
+
+# Find or insert a string in the interned set.
+#
+# Shared (from Intern):
+#   sentinel
+#
+# Inputs:
+#   a0: pointer to string data
+#   a1: size of string
+#   a2: tree
+#
+# Outputs:
+#   a0: pointer to interned string data
+#   a1: size of string
+#   a2: updated tree
+"strintern.findOrInsert":
+	#define str_data s1
+	#define str_size s2
+	#define tree     s3
+
+	.cfi_startproc
+	save_3
+	mv str_data, a0
+	mv str_size, a1
+	mv tree, a2
+
+	# Allocation should be rarer, so put it last.
+	beq tree, sentinel, .LfindOrInsert.allocate
+
+	# a0 and a1 are ready.
+	ld a2, "strintern.node.str_data"(tree)
+	lw a3, "strintern.node.str_size"(tree)
+	call "mem/Shortlex"
+
+	bltz a0, .LfindOrUpdate.left
+	bgtz a0, .LfindOrUpdate.right
+
+.LfindOrUpdate.found:
+	# Return interned value.
+	ld str_data, "strintern.node.str_data"(tree)
+	lw str_size, "strintern.node.str_size"(tree)
+
+	j .LfindOrInsert.end
+
+.LfindOrUpdate.left:
+	mv a0, str_data
+	mv a1, str_size
+	ld a2, "strintern.node.left"(tree)
+	call "strintern.findOrInsert"
+
+	j .LfindOrUpdate.rebalance
+
+.LfindOrUpdate.right:
+	mv a0, str_data
+	mv a1, str_size
+	ld a2, "strintern.node.right"(tree)
+	call "strintern.findOrInsert"
+
+	# Fall through.
+
+.LfindOrUpdate.rebalance:
+	mv str_data, a0
+	mv str_size, a1
+	mv a0, a2
+
+	# skew and split modify and return a0.
+	call "strintern.skew"
+	call "strintern.split"
+	mv tree, a0
+
+	# Fall through.
+
+.LfindOrInsert.end:
+	mv a0, str_data
+	mv a1, str_size
+	mv a2, tree
+	restore_3
+
+.LfindOrInsert.allocate:
+	li a0, "strintern.node_size"
+	call "forever.MustAllocate"
+	mv tree, a0
+
+	sd sentinel, "strintern.node.left"(tree)
+	sd sentinel, "strintern.node.right"(tree)
+
+	li t0, 1
+	sd t0, "strintern.node.level"(tree)
+
+	# Store a clone of the string that is guaranteed not to alias with
+	# anything, removing the need to compare string lengths and thus
+	# reducing string comparison to a single instruction.
+	mv a0, str_size
+	mv a1, str_data
+	call "mem.Clone"
+	mv str_data, a1
+
+	sd str_size, "strintern.node.str_size"(tree)
+	sd str_data, "strintern.node.str_data"(tree)
+
+	j .LfindOrInsert.end
+	.cfi_endproc
+
+	#undef str_data
+	#undef str_size
+	#undef tree
+
+	# Undefine shared registers.
+	#undef sentinel
+
+# Inputs:
+#   a0: node pointer
+#
+# Outputs:
+#   a0: node pointer
+#
+# Rotation:
+#
+#   L <---- [T]       [L] ----> T
+#  / \       \   =>   /        / \
+# A   B       R      A        B   R
+"strintern.skew":
+	#define t       a0
+	#define l       t0
+	#define t_level t1
+	#define l_level t2
+	#define b       t3
+
+	.cfi_startproc
+	ld l, "strintern.node.left"(t)
+	lw t_level, "strintern.node.level"(t)
+	lw l_level, "strintern.node.level"(l)
+	beq t_level, l_level, .Lskew.rotate
+	ret
+
+.Lskew.rotate:
+	ld b, "strintern.node.right"(l)
+	sd b, "strintern.node.left"(t)
+	sd t, "strintern.node.right"(l)
+	mv t, l
+	ret
+	.cfi_endproc
+
+	#undef t
+	#undef l
+	#undef t_level
+	#undef l_level
+	#undef b
+
+
+# Inputs:
+#   a0: node pointer
+#
+# Outputs:
+#   a0: node pointer
+#
+# Rotation:
+#
+#  [T] ---> R ---> X           [R]
+#  /       /            =>    /  \
+# L       B                  T    X
+#                           / \
+#                          L   B
+"strintern.split":
+	#define t       a0
+	#define r       t0
+	#define x       t1
+	#define t_level t2
+	#define x_level t3
+	#define b       t4
+	#define r_level t5
+
+	.cfi_startproc
+	ld r, "strintern.node.right"(t)
+	ld x, "strintern.node.right"(r)
+
+	lw t_level, "strintern.node.level"(t)
+	lw x_level, "strintern.node.level"(x)
+	beq t_level, x_level, .Lsplit.rotate
+
+	ret
+
+.Lsplit.rotate:
+	ld b, "strintern.node.left"(r)
+	sd b, "strintern.node.right"(t)
+	sd t, "strintern.node.left"(r)
+
+	lw r_level, "strintern.node.level"(r)
+	addi r_level, r_level, 1
+	sw r_level, "strintern.node.level"(r)
+
+	ret
+	.cfi_endproc
+
+	#undef t
+	#undef r
+	#undef x
+	#undef t_level
+	#undef x_level
+	#undef b
+	#undef r_level

--- a/lib/p0/strintern/strintern_internal_test.S
+++ b/lib/p0/strintern/strintern_internal_test.S
@@ -1,0 +1,313 @@
+# ===========================================================================
+# String interning tests
+# ===========================================================================
+
+# Include the source directly because this is an internal test.
+#include "strintern.S"
+
+#include <safe_str.S>
+#include <testing.S>
+
+
+# ===========================================================================
+# Test data
+# ===========================================================================
+
+.section .rodata
+
+safe_str str0, "bb"
+safe_str str0_copy, "bb"
+
+safe_str smaller_1, "a"
+safe_str smaller_1_copy, "a"
+
+safe_str bigger_1, "zzz"
+safe_str bigger_1_copy, "zzz"
+
+safe_str strs, "abcdefghijklmnopqrstuvwxyz"
+safe_str strs_copy, "abcdefghijklmnopqrstuvwxyz"
+
+
+# ===========================================================================
+# Test cases
+# ===========================================================================
+test_case sentinel_has_expected_size
+	li t0, "strintern.sentinel_size"
+	li t1, "strintern.node_size"
+	expect_eq t0, t1
+	ret
+end_test
+
+test_case sentinel_left_and_right_point_to_itself
+	#define sentinel t0
+	#define l        t1
+	#define r        t2
+
+	la sentinel, "strintern.sentinel"
+
+	ld l, "strintern.node.left"(sentinel)
+	expect_eq sentinel, l
+
+	ld r, "strintern.node.right"(sentinel)
+	expect_eq sentinel, r
+
+	ret
+
+	#undef sentinel
+	#undef l
+	#undef r
+end_test
+
+test_case Intern_first_string
+	save_0
+	call cleanSlate
+
+	la a0, str0
+	li a1, str0_size
+	mv a2, a0
+	mv a3, a1
+	call expectIntern
+
+	restore_0
+end_test
+
+test_case Intern_first_string_twice
+	save_0
+	call cleanSlate
+
+	la a0, str0
+	li a1, str0_size
+	mv a2, a0
+	mv a3, a1
+	call expectIntern
+
+	la a0, str0_copy
+	li a1, str0_copy_size
+	la a2, str0
+	li a3, str0_size
+	call expectIntern
+
+	restore_0
+end_test
+
+test_case Intern_smaller
+	save_0
+	call cleanSlate
+
+	la a0, str0
+	li a1, str0_size
+	mv a2, a0
+	mv a3, a1
+	call expectIntern
+
+	la a0, smaller_1
+	li a1, smaller_1_size
+	la a2, smaller_1
+	li a3, smaller_1_size
+	call expectIntern
+
+	la a0, smaller_1_copy
+	li a1, smaller_1_copy_size
+	la a2, smaller_1
+	li a3, smaller_1_size
+	call expectIntern
+
+	restore_0
+end_test
+
+test_case Intern_bigger
+	save_0
+	call cleanSlate
+
+	la a0, str0
+	li a1, str0_size
+	mv a2, a0
+	mv a3, a1
+	call expectIntern
+
+	la a0, bigger_1
+	li a1, bigger_1_size
+	la a2, bigger_1
+	li a3, bigger_1_size
+	call expectIntern
+
+	la a0, bigger_1_copy
+	li a1, bigger_1_copy_size
+	la a2, bigger_1
+	li a3, bigger_1_size
+	call expectIntern
+
+	restore_0
+end_test
+
+test_case Intern_many
+	# Callee-saved registers.
+	#define p   s1
+	#define end s2
+
+	save_2
+	call cleanSlate
+
+	la p, strs
+	addi end, p, strs_size
+
+.LIntern_many_loop:
+	mv a0, p
+	li a1, 1
+	mv a2, a0
+	mv a3, a1
+	call expectIntern
+
+	add p, p, 1
+	bltu p, end, .LIntern_many_loop
+
+	restore_2
+
+	#undef p
+	#undef end
+end_test
+
+test_case Intern_many_twice
+	# Callee-saved registers.
+	#define p   s1
+	#define end s2
+
+	# Inserts a lot of size-1 strings.
+	save_2
+	call cleanSlate
+
+	la p, strs
+	add end, p, strs_size
+
+.LIntern_many_loop_1:
+	mv a0, p
+	li a1, 1
+	mv a2, a0
+	mv a3, a1
+	call expectIntern
+
+	addi p, p, 1
+	bltu p, end, .LIntern_many_loop_1
+
+	la p, strs
+
+.LIntern_many_loop_2:
+	mv a0, p
+	li a1, 1
+	mv a2, a0
+	mv a3, a1
+	call expectIntern
+
+	add p, p, 1
+	bltu p, end, .LIntern_many_loop_2
+
+	restore_2
+
+	#undef p
+	#undef end
+end_test
+
+test_case Intern_many_and_copies
+	# Callee-saved registers.
+	#define p      s1
+	#define end    s2
+	#define p_copy s3
+
+	# Inserts a lot of size-1 strings.
+	save_3
+	call cleanSlate
+
+	la p, strs
+	add end, p, strs_size
+
+.LIntern_many_and_copies_loop_1:
+	mv a0, p
+	li a1, 1
+	mv a2, a0
+	mv a3, a1
+	call expectIntern
+
+	addi p, p, 1
+	bltu p, end, .LIntern_many_and_copies_loop_1
+
+	la p_copy, strs_copy
+	la p, strs
+	add end, p, strs_size
+
+.LIntern_many_and_copies_loop_2:
+	mv a0, p_copy
+	li a1, 1
+	mv a2, p
+	li a3, 1
+	call expectIntern
+
+	addi p, p, 1
+	addi p_copy, p_copy, 1
+	bltu p, end, .LIntern_many_and_copies_loop_2
+
+	restore_3
+
+	#undef p
+	#undef end
+	#undef p_copy
+end_test
+
+
+# ===========================================================================
+# Test helpers
+# ===========================================================================
+
+.section .text
+
+# Clean the interned string set.
+#
+# Leaks memory. Only for use in tests.
+cleanSlate:
+	#define sentinel t0
+	#define root     t1
+
+	.cfi_startproc
+	la sentinel, "strintern.sentinel"
+	la root, "strintern.root"
+	sd sentinel, 0(root)
+	ret
+	.cfi_endproc
+
+	#undef sentinel
+	#undef root
+
+
+# Inputs:
+#   a0: input string data
+#   a1: input string size
+#   a2: expected string data
+#   a3: expected string size
+expectIntern:
+	#define expected_size s1
+	#define expected_data s2
+	#define actual_size   s3
+	#define actual_data   s4
+
+	.cfi_startproc
+	save_4
+
+	mv expected_size, a3
+	mv expected_data, a2
+
+	# a0 and a1 are already set.
+	call "strintern.Intern"
+
+	mv actual_data, a0
+	mv actual_size, a1
+
+	mv a2, expected_data
+	mv a3, expected_size
+	call "mem.Eq"
+
+	expect_eqi 1, a0
+
+	restore_4
+	.cfi_endproc
+
+	#undef expected_date
+	#undef expected_size

--- a/make
+++ b/make
@@ -232,32 +232,37 @@ build_library lib/libtesting.a \
 	"$BUILD_ROOT/lib/testing/testing.o"
 
 section Build the p0 library.
-assemble lib/p0/forever/allocate.S
 assemble lib/p0/ascii/ascii.S
 assemble lib/p0/mem/clone.S
 assemble lib/p0/mem/copy.S
+assemble lib/p0/forever/allocate.S
+assemble lib/p0/io/write.S
+assemble lib/p0/os/exit.S
 assemble lib/p0/mem/eq.S
 assemble lib/p0/mem/index.S
 assemble lib/p0/mem/shortlex.S
-assemble lib/p0/io/write.S
-assemble lib/p0/os/exit.S
+assemble lib/p0/strintern/strintern.S
 
 build_library lib/libp0.a \
-	"$BUILD_ROOT/lib/p0/forever/allocate.o" \
 	"$BUILD_ROOT/lib/p0/ascii/ascii.o" \
 	"$BUILD_ROOT/lib/p0/mem/clone.o" \
 	"$BUILD_ROOT/lib/p0/mem/copy.o" \
+	"$BUILD_ROOT/lib/p0/forever/allocate.o" \
+	"$BUILD_ROOT/lib/p0/io/write.o" \
+	"$BUILD_ROOT/lib/p0/os/exit.o" \
 	"$BUILD_ROOT/lib/p0/mem/eq.o" \
 	"$BUILD_ROOT/lib/p0/mem/index.o" \
 	"$BUILD_ROOT/lib/p0/mem/shortlex.o" \
-	"$BUILD_ROOT/lib/p0/io/write.o" \
-	"$BUILD_ROOT/lib/p0/os/exit.o"
+	"$BUILD_ROOT/lib/p0/strintern/strintern.o"
 
 section Test the p0 library.
+with_test lib/p0/ascii/ascii_test \
+	"$BUILD_ROOT/lib/libp0.a"
+
 with_test lib/p0/forever/allocate_test \
 	"$BUILD_ROOT/lib/libp0.a"
 
-with_test lib/p0/ascii/ascii_test \
+with_test lib/p0/io/write_test \
 	"$BUILD_ROOT/lib/libp0.a"
 
 with_test lib/p0/mem/clone_test \
@@ -275,7 +280,7 @@ with_test lib/p0/mem/index_test \
 with_test lib/p0/mem/shortlex_test \
 	"$BUILD_ROOT/lib/libp0.a"
 
-with_test lib/p0/io/write_test \
+with_test lib/p0/strintern/strintern_internal_test \
 	"$BUILD_ROOT/lib/libp0.a"
 
 section Build a simple program that uses the p0 library.


### PR DESCRIPTION
This package provides interning of strings up to 4 GiB in size on
64-bit architectures, which should be way more than enough for the
purpose of building compilers and operating systems.