### PR TITLE
format.Signed: introduce two-level test macro

### DIFF
--- a/lib/p0/format/signed_test.S
+++ b/lib/p0/format/signed_test.S
@@ -28,40 +28,40 @@ safe_str quote_end, "\"\n"
 # Test macros
 # ===========================================================================
 
-.macro check value, buffer_size, idx, updated_idx, expected
+.macro check name, value, buffer_size, idx, updated_idx, expected
 	# Reserve 32 bytes regardless of intended buffer size to mitigate the
 	# risk of buffer overruns affecting other test cases.
 	.section .bss
 	.p2align 3
-	.lcomm "Signed_\value\()_\buffer_size\()_\idx\()_buffer_data", 32
+	.lcomm "\name\()_buffer_data", 32
 
 	.section .rodata
 	.p2align 3
-	safe_str "Signed_\value\()_\buffer_size\()_\idx\()_expected", "\expected"
+	safe_str "\name\()_expected", "\expected"
 
 	.section .text
-	test_case "Signed_\value\()_\buffer_size\()_\idx"
+	test_case "\name"
 		save_4
 
 		# Call function under test.
 		la a0, \buffer_size
-		la a1, "Signed_\value\()_\buffer_size\()_\idx\()_buffer_data"
+		la a1, "\name\()_buffer_data"
 		li a2, \idx
 		li a3, \value
 		call "format.Signed"
 
 		# Check invariants (buffer data pointer and size).
 		expect_eqi \buffer_size, a0
-		expect_eqa "Signed_\value\()_\buffer_size\()_\idx\()_buffer_data", a1
+		expect_eqa "\name\()_buffer_data", a1
 
 		# Check that the buffer index has been updated.
 		expect_eqi \updated_idx, a2
 
 		# Check that the string representation is as expected.
-		li s1, "Signed_\value\()_\buffer_size\()_\idx\()_expected_size"
-		la s2, "Signed_\value\()_\buffer_size\()_\idx\()_expected_data"
+		li s1, "\name\()_expected_size"
+		la s2, "\name\()_expected_data"
 		li s3, \updated_idx - \idx
-		la s4, "Signed_\value\()_\buffer_size\()_\idx\()_buffer_data" + \idx
+		la s4, "\name\()_buffer_data" + \idx
 
 		mv a0, s1
 		mv a1, s2
@@ -71,7 +71,7 @@ safe_str quote_end, "\"\n"
 		expect_eqi 1, a0
 
 		ld t0, "testing_state.test_failed"(tp)
-		beqz t0, ".LSigned_\value\()_\buffer_size\()_\idx\().end"
+		beqz t0, ".L\name\().end"
 
 		li a0, STDLOG
 		li a1, expected_label_size
@@ -113,14 +113,24 @@ safe_str quote_end, "\"\n"
 		la a2, quote_end_data
 		call "io.Write"
 
-	".LSigned_\value\()_\buffer_size\()_\idx\().end":
+	".L\name\().end":
 		restore_4
 	end_test
 .endm
 
+.macro pcheck value, buffer_size, idx, updated_idx, expected
+	check \
+		name="Signed_\value\()_\buffer_size\()_\idx", \
+		value="\value", \
+		buffer_size="\buffer_size" \
+		idx="\idx", \
+		updated_idx="\updated_idx", \
+		expected="\expected"
+.endm
+
 
 # ===========================================================================
-# Test cases
+# Test cases for positive numbers
 # ===========================================================================
 
 .section .text
@@ -143,216 +153,223 @@ test_case Signed_does_not_write_to_nil_output
 end_test
 
 # Test all positive single digits (no space).
-check value=0, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=1, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=2, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=3, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=4, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=5, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=6, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=7, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=8, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=9, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=0, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=1, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=2, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=3, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=4, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=5, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=6, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=7, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=8, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=9, buffer_size=0, idx=0, updated_idx=0, expected=""
 
 # Test all positive single digits (exact space).
-check value=0, buffer_size=1, idx=0, updated_idx=1, expected="0"
-check value=1, buffer_size=1, idx=0, updated_idx=1, expected="1"
-check value=2, buffer_size=1, idx=0, updated_idx=1, expected="2"
-check value=3, buffer_size=1, idx=0, updated_idx=1, expected="3"
-check value=4, buffer_size=1, idx=0, updated_idx=1, expected="4"
-check value=5, buffer_size=1, idx=0, updated_idx=1, expected="5"
-check value=6, buffer_size=1, idx=0, updated_idx=1, expected="6"
-check value=7, buffer_size=1, idx=0, updated_idx=1, expected="7"
-check value=8, buffer_size=1, idx=0, updated_idx=1, expected="8"
-check value=9, buffer_size=1, idx=0, updated_idx=1, expected="9"
+pcheck value=0, buffer_size=1, idx=0, updated_idx=1, expected="0"
+pcheck value=1, buffer_size=1, idx=0, updated_idx=1, expected="1"
+pcheck value=2, buffer_size=1, idx=0, updated_idx=1, expected="2"
+pcheck value=3, buffer_size=1, idx=0, updated_idx=1, expected="3"
+pcheck value=4, buffer_size=1, idx=0, updated_idx=1, expected="4"
+pcheck value=5, buffer_size=1, idx=0, updated_idx=1, expected="5"
+pcheck value=6, buffer_size=1, idx=0, updated_idx=1, expected="6"
+pcheck value=7, buffer_size=1, idx=0, updated_idx=1, expected="7"
+pcheck value=8, buffer_size=1, idx=0, updated_idx=1, expected="8"
+pcheck value=9, buffer_size=1, idx=0, updated_idx=1, expected="9"
 
 # Test all positive single digits (extra space).
-check value=0, buffer_size=2, idx=0, updated_idx=1, expected="0"
-check value=1, buffer_size=2, idx=0, updated_idx=1, expected="1"
-check value=2, buffer_size=2, idx=0, updated_idx=1, expected="2"
-check value=3, buffer_size=2, idx=0, updated_idx=1, expected="3"
-check value=4, buffer_size=2, idx=0, updated_idx=1, expected="4"
-check value=5, buffer_size=2, idx=0, updated_idx=1, expected="5"
-check value=6, buffer_size=2, idx=0, updated_idx=1, expected="6"
-check value=7, buffer_size=2, idx=0, updated_idx=1, expected="7"
-check value=8, buffer_size=2, idx=0, updated_idx=1, expected="8"
-check value=9, buffer_size=2, idx=0, updated_idx=1, expected="9"
+pcheck value=0, buffer_size=2, idx=0, updated_idx=1, expected="0"
+pcheck value=1, buffer_size=2, idx=0, updated_idx=1, expected="1"
+pcheck value=2, buffer_size=2, idx=0, updated_idx=1, expected="2"
+pcheck value=3, buffer_size=2, idx=0, updated_idx=1, expected="3"
+pcheck value=4, buffer_size=2, idx=0, updated_idx=1, expected="4"
+pcheck value=5, buffer_size=2, idx=0, updated_idx=1, expected="5"
+pcheck value=6, buffer_size=2, idx=0, updated_idx=1, expected="6"
+pcheck value=7, buffer_size=2, idx=0, updated_idx=1, expected="7"
+pcheck value=8, buffer_size=2, idx=0, updated_idx=1, expected="8"
+pcheck value=9, buffer_size=2, idx=0, updated_idx=1, expected="9"
 
 # Test all positive single digits (offset 1).
-check value=0, buffer_size=2, idx=1, updated_idx=2, expected="0"
-check value=1, buffer_size=2, idx=1, updated_idx=2, expected="1"
-check value=2, buffer_size=2, idx=1, updated_idx=2, expected="2"
-check value=3, buffer_size=2, idx=1, updated_idx=2, expected="3"
-check value=4, buffer_size=2, idx=1, updated_idx=2, expected="4"
-check value=5, buffer_size=2, idx=1, updated_idx=2, expected="5"
-check value=6, buffer_size=2, idx=1, updated_idx=2, expected="6"
-check value=7, buffer_size=2, idx=1, updated_idx=2, expected="7"
-check value=8, buffer_size=2, idx=1, updated_idx=2, expected="8"
-check value=9, buffer_size=2, idx=1, updated_idx=2, expected="9"
+pcheck value=0, buffer_size=2, idx=1, updated_idx=2, expected="0"
+pcheck value=1, buffer_size=2, idx=1, updated_idx=2, expected="1"
+pcheck value=2, buffer_size=2, idx=1, updated_idx=2, expected="2"
+pcheck value=3, buffer_size=2, idx=1, updated_idx=2, expected="3"
+pcheck value=4, buffer_size=2, idx=1, updated_idx=2, expected="4"
+pcheck value=5, buffer_size=2, idx=1, updated_idx=2, expected="5"
+pcheck value=6, buffer_size=2, idx=1, updated_idx=2, expected="6"
+pcheck value=7, buffer_size=2, idx=1, updated_idx=2, expected="7"
+pcheck value=8, buffer_size=2, idx=1, updated_idx=2, expected="8"
+pcheck value=9, buffer_size=2, idx=1, updated_idx=2, expected="9"
 
 
 # Test 2 digits (no space).
-check value=10, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=19, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=20, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=29, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=30, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=39, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=40, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=49, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=50, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=59, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=60, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=69, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=70, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=79, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=80, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=89, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=90, buffer_size=0, idx=0, updated_idx=0, expected=""
-check value=99, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=10, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=19, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=20, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=29, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=30, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=39, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=40, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=49, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=50, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=59, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=60, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=69, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=70, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=79, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=80, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=89, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=90, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=99, buffer_size=0, idx=0, updated_idx=0, expected=""
 
 # Test 2 digits (truncated).
-check value=10, buffer_size=1, idx=0, updated_idx=1, expected="1"
-check value=19, buffer_size=1, idx=0, updated_idx=1, expected="1"
-check value=20, buffer_size=1, idx=0, updated_idx=1, expected="2"
-check value=29, buffer_size=1, idx=0, updated_idx=1, expected="2"
-check value=30, buffer_size=1, idx=0, updated_idx=1, expected="3"
-check value=39, buffer_size=1, idx=0, updated_idx=1, expected="3"
-check value=40, buffer_size=1, idx=0, updated_idx=1, expected="4"
-check value=49, buffer_size=1, idx=0, updated_idx=1, expected="4"
-check value=50, buffer_size=1, idx=0, updated_idx=1, expected="5"
-check value=59, buffer_size=1, idx=0, updated_idx=1, expected="5"
-check value=60, buffer_size=1, idx=0, updated_idx=1, expected="6"
-check value=69, buffer_size=1, idx=0, updated_idx=1, expected="6"
-check value=70, buffer_size=1, idx=0, updated_idx=1, expected="7"
-check value=79, buffer_size=1, idx=0, updated_idx=1, expected="7"
-check value=80, buffer_size=1, idx=0, updated_idx=1, expected="8"
-check value=89, buffer_size=1, idx=0, updated_idx=1, expected="8"
-check value=90, buffer_size=1, idx=0, updated_idx=1, expected="9"
-check value=99, buffer_size=1, idx=0, updated_idx=1, expected="9"
+pcheck value=10, buffer_size=1, idx=0, updated_idx=1, expected="1"
+pcheck value=19, buffer_size=1, idx=0, updated_idx=1, expected="1"
+pcheck value=20, buffer_size=1, idx=0, updated_idx=1, expected="2"
+pcheck value=29, buffer_size=1, idx=0, updated_idx=1, expected="2"
+pcheck value=30, buffer_size=1, idx=0, updated_idx=1, expected="3"
+pcheck value=39, buffer_size=1, idx=0, updated_idx=1, expected="3"
+pcheck value=40, buffer_size=1, idx=0, updated_idx=1, expected="4"
+pcheck value=49, buffer_size=1, idx=0, updated_idx=1, expected="4"
+pcheck value=50, buffer_size=1, idx=0, updated_idx=1, expected="5"
+pcheck value=59, buffer_size=1, idx=0, updated_idx=1, expected="5"
+pcheck value=60, buffer_size=1, idx=0, updated_idx=1, expected="6"
+pcheck value=69, buffer_size=1, idx=0, updated_idx=1, expected="6"
+pcheck value=70, buffer_size=1, idx=0, updated_idx=1, expected="7"
+pcheck value=79, buffer_size=1, idx=0, updated_idx=1, expected="7"
+pcheck value=80, buffer_size=1, idx=0, updated_idx=1, expected="8"
+pcheck value=89, buffer_size=1, idx=0, updated_idx=1, expected="8"
+pcheck value=90, buffer_size=1, idx=0, updated_idx=1, expected="9"
+pcheck value=99, buffer_size=1, idx=0, updated_idx=1, expected="9"
 
 # Test 2 digits (exact space).
-check value=10, buffer_size=2, idx=0, updated_idx=2, expected="10"
-check value=19, buffer_size=2, idx=0, updated_idx=2, expected="19"
-check value=20, buffer_size=2, idx=0, updated_idx=2, expected="20"
-check value=29, buffer_size=2, idx=0, updated_idx=2, expected="29"
-check value=30, buffer_size=2, idx=0, updated_idx=2, expected="30"
-check value=39, buffer_size=2, idx=0, updated_idx=2, expected="39"
-check value=40, buffer_size=2, idx=0, updated_idx=2, expected="40"
-check value=49, buffer_size=2, idx=0, updated_idx=2, expected="49"
-check value=50, buffer_size=2, idx=0, updated_idx=2, expected="50"
-check value=59, buffer_size=2, idx=0, updated_idx=2, expected="59"
-check value=60, buffer_size=2, idx=0, updated_idx=2, expected="60"
-check value=69, buffer_size=2, idx=0, updated_idx=2, expected="69"
-check value=70, buffer_size=2, idx=0, updated_idx=2, expected="70"
-check value=79, buffer_size=2, idx=0, updated_idx=2, expected="79"
-check value=80, buffer_size=2, idx=0, updated_idx=2, expected="80"
-check value=89, buffer_size=2, idx=0, updated_idx=2, expected="89"
-check value=90, buffer_size=2, idx=0, updated_idx=2, expected="90"
-check value=99, buffer_size=2, idx=0, updated_idx=2, expected="99"
+pcheck value=10, buffer_size=2, idx=0, updated_idx=2, expected="10"
+pcheck value=19, buffer_size=2, idx=0, updated_idx=2, expected="19"
+pcheck value=20, buffer_size=2, idx=0, updated_idx=2, expected="20"
+pcheck value=29, buffer_size=2, idx=0, updated_idx=2, expected="29"
+pcheck value=30, buffer_size=2, idx=0, updated_idx=2, expected="30"
+pcheck value=39, buffer_size=2, idx=0, updated_idx=2, expected="39"
+pcheck value=40, buffer_size=2, idx=0, updated_idx=2, expected="40"
+pcheck value=49, buffer_size=2, idx=0, updated_idx=2, expected="49"
+pcheck value=50, buffer_size=2, idx=0, updated_idx=2, expected="50"
+pcheck value=59, buffer_size=2, idx=0, updated_idx=2, expected="59"
+pcheck value=60, buffer_size=2, idx=0, updated_idx=2, expected="60"
+pcheck value=69, buffer_size=2, idx=0, updated_idx=2, expected="69"
+pcheck value=70, buffer_size=2, idx=0, updated_idx=2, expected="70"
+pcheck value=79, buffer_size=2, idx=0, updated_idx=2, expected="79"
+pcheck value=80, buffer_size=2, idx=0, updated_idx=2, expected="80"
+pcheck value=89, buffer_size=2, idx=0, updated_idx=2, expected="89"
+pcheck value=90, buffer_size=2, idx=0, updated_idx=2, expected="90"
+pcheck value=99, buffer_size=2, idx=0, updated_idx=2, expected="99"
 
 # Test 2 digits (extra space).
-check value=10, buffer_size=3, idx=0, updated_idx=2, expected="10"
-check value=19, buffer_size=3, idx=0, updated_idx=2, expected="19"
-check value=20, buffer_size=3, idx=0, updated_idx=2, expected="20"
-check value=29, buffer_size=3, idx=0, updated_idx=2, expected="29"
-check value=30, buffer_size=3, idx=0, updated_idx=2, expected="30"
-check value=39, buffer_size=3, idx=0, updated_idx=2, expected="39"
-check value=40, buffer_size=3, idx=0, updated_idx=2, expected="40"
-check value=49, buffer_size=3, idx=0, updated_idx=2, expected="49"
-check value=50, buffer_size=3, idx=0, updated_idx=2, expected="50"
-check value=59, buffer_size=3, idx=0, updated_idx=2, expected="59"
-check value=60, buffer_size=3, idx=0, updated_idx=2, expected="60"
-check value=69, buffer_size=3, idx=0, updated_idx=2, expected="69"
-check value=70, buffer_size=3, idx=0, updated_idx=2, expected="70"
-check value=79, buffer_size=3, idx=0, updated_idx=2, expected="79"
-check value=80, buffer_size=3, idx=0, updated_idx=2, expected="80"
-check value=89, buffer_size=3, idx=0, updated_idx=2, expected="89"
-check value=90, buffer_size=3, idx=0, updated_idx=2, expected="90"
-check value=99, buffer_size=3, idx=0, updated_idx=2, expected="99"
+pcheck value=10, buffer_size=3, idx=0, updated_idx=2, expected="10"
+pcheck value=19, buffer_size=3, idx=0, updated_idx=2, expected="19"
+pcheck value=20, buffer_size=3, idx=0, updated_idx=2, expected="20"
+pcheck value=29, buffer_size=3, idx=0, updated_idx=2, expected="29"
+pcheck value=30, buffer_size=3, idx=0, updated_idx=2, expected="30"
+pcheck value=39, buffer_size=3, idx=0, updated_idx=2, expected="39"
+pcheck value=40, buffer_size=3, idx=0, updated_idx=2, expected="40"
+pcheck value=49, buffer_size=3, idx=0, updated_idx=2, expected="49"
+pcheck value=50, buffer_size=3, idx=0, updated_idx=2, expected="50"
+pcheck value=59, buffer_size=3, idx=0, updated_idx=2, expected="59"
+pcheck value=60, buffer_size=3, idx=0, updated_idx=2, expected="60"
+pcheck value=69, buffer_size=3, idx=0, updated_idx=2, expected="69"
+pcheck value=70, buffer_size=3, idx=0, updated_idx=2, expected="70"
+pcheck value=79, buffer_size=3, idx=0, updated_idx=2, expected="79"
+pcheck value=80, buffer_size=3, idx=0, updated_idx=2, expected="80"
+pcheck value=89, buffer_size=3, idx=0, updated_idx=2, expected="89"
+pcheck value=90, buffer_size=3, idx=0, updated_idx=2, expected="90"
+pcheck value=99, buffer_size=3, idx=0, updated_idx=2, expected="99"
 
 # Test 2 digits (offset 1).
-check value=10, buffer_size=3, idx=1, updated_idx=3, expected="10"
-check value=19, buffer_size=3, idx=1, updated_idx=3, expected="19"
-check value=20, buffer_size=3, idx=1, updated_idx=3, expected="20"
-check value=29, buffer_size=3, idx=1, updated_idx=3, expected="29"
-check value=30, buffer_size=3, idx=1, updated_idx=3, expected="30"
-check value=39, buffer_size=3, idx=1, updated_idx=3, expected="39"
-check value=40, buffer_size=3, idx=1, updated_idx=3, expected="40"
-check value=49, buffer_size=3, idx=1, updated_idx=3, expected="49"
-check value=50, buffer_size=3, idx=1, updated_idx=3, expected="50"
-check value=59, buffer_size=3, idx=1, updated_idx=3, expected="59"
-check value=60, buffer_size=3, idx=1, updated_idx=3, expected="60"
-check value=69, buffer_size=3, idx=1, updated_idx=3, expected="69"
-check value=70, buffer_size=3, idx=1, updated_idx=3, expected="70"
-check value=79, buffer_size=3, idx=1, updated_idx=3, expected="79"
-check value=80, buffer_size=3, idx=1, updated_idx=3, expected="80"
-check value=89, buffer_size=3, idx=1, updated_idx=3, expected="89"
-check value=90, buffer_size=3, idx=1, updated_idx=3, expected="90"
-check value=99, buffer_size=3, idx=1, updated_idx=3, expected="99"
+pcheck value=10, buffer_size=3, idx=1, updated_idx=3, expected="10"
+pcheck value=19, buffer_size=3, idx=1, updated_idx=3, expected="19"
+pcheck value=20, buffer_size=3, idx=1, updated_idx=3, expected="20"
+pcheck value=29, buffer_size=3, idx=1, updated_idx=3, expected="29"
+pcheck value=30, buffer_size=3, idx=1, updated_idx=3, expected="30"
+pcheck value=39, buffer_size=3, idx=1, updated_idx=3, expected="39"
+pcheck value=40, buffer_size=3, idx=1, updated_idx=3, expected="40"
+pcheck value=49, buffer_size=3, idx=1, updated_idx=3, expected="49"
+pcheck value=50, buffer_size=3, idx=1, updated_idx=3, expected="50"
+pcheck value=59, buffer_size=3, idx=1, updated_idx=3, expected="59"
+pcheck value=60, buffer_size=3, idx=1, updated_idx=3, expected="60"
+pcheck value=69, buffer_size=3, idx=1, updated_idx=3, expected="69"
+pcheck value=70, buffer_size=3, idx=1, updated_idx=3, expected="70"
+pcheck value=79, buffer_size=3, idx=1, updated_idx=3, expected="79"
+pcheck value=80, buffer_size=3, idx=1, updated_idx=3, expected="80"
+pcheck value=89, buffer_size=3, idx=1, updated_idx=3, expected="89"
+pcheck value=90, buffer_size=3, idx=1, updated_idx=3, expected="90"
+pcheck value=99, buffer_size=3, idx=1, updated_idx=3, expected="99"
 
 # Test 3 digits (exact space).
-check value=150, buffer_size=3, idx=0, updated_idx=3, expected="150"
-check value=159, buffer_size=3, idx=0, updated_idx=3, expected="159"
-check value=250, buffer_size=3, idx=0, updated_idx=3, expected="250"
-check value=259, buffer_size=3, idx=0, updated_idx=3, expected="259"
-check value=350, buffer_size=3, idx=0, updated_idx=3, expected="350"
-check value=359, buffer_size=3, idx=0, updated_idx=3, expected="359"
-check value=450, buffer_size=3, idx=0, updated_idx=3, expected="450"
-check value=459, buffer_size=3, idx=0, updated_idx=3, expected="459"
-check value=550, buffer_size=3, idx=0, updated_idx=3, expected="550"
-check value=559, buffer_size=3, idx=0, updated_idx=3, expected="559"
-check value=650, buffer_size=3, idx=0, updated_idx=3, expected="650"
-check value=659, buffer_size=3, idx=0, updated_idx=3, expected="659"
-check value=750, buffer_size=3, idx=0, updated_idx=3, expected="750"
-check value=759, buffer_size=3, idx=0, updated_idx=3, expected="759"
-check value=850, buffer_size=3, idx=0, updated_idx=3, expected="850"
-check value=859, buffer_size=3, idx=0, updated_idx=3, expected="859"
-check value=950, buffer_size=3, idx=0, updated_idx=3, expected="950"
-check value=959, buffer_size=3, idx=0, updated_idx=3, expected="959"
+pcheck value=150, buffer_size=3, idx=0, updated_idx=3, expected="150"
+pcheck value=159, buffer_size=3, idx=0, updated_idx=3, expected="159"
+pcheck value=250, buffer_size=3, idx=0, updated_idx=3, expected="250"
+pcheck value=259, buffer_size=3, idx=0, updated_idx=3, expected="259"
+pcheck value=350, buffer_size=3, idx=0, updated_idx=3, expected="350"
+pcheck value=359, buffer_size=3, idx=0, updated_idx=3, expected="359"
+pcheck value=450, buffer_size=3, idx=0, updated_idx=3, expected="450"
+pcheck value=459, buffer_size=3, idx=0, updated_idx=3, expected="459"
+pcheck value=550, buffer_size=3, idx=0, updated_idx=3, expected="550"
+pcheck value=559, buffer_size=3, idx=0, updated_idx=3, expected="559"
+pcheck value=650, buffer_size=3, idx=0, updated_idx=3, expected="650"
+pcheck value=659, buffer_size=3, idx=0, updated_idx=3, expected="659"
+pcheck value=750, buffer_size=3, idx=0, updated_idx=3, expected="750"
+pcheck value=759, buffer_size=3, idx=0, updated_idx=3, expected="759"
+pcheck value=850, buffer_size=3, idx=0, updated_idx=3, expected="850"
+pcheck value=859, buffer_size=3, idx=0, updated_idx=3, expected="859"
+pcheck value=950, buffer_size=3, idx=0, updated_idx=3, expected="950"
+pcheck value=959, buffer_size=3, idx=0, updated_idx=3, expected="959"
 
 # Maximum value (exact space).
-check value=9223372036854775807, buffer_size=19, idx=0, updated_idx=19, expected="9223372036854775807"
+pcheck value=9223372036854775807, buffer_size=19, idx=0, updated_idx=19, expected="9223372036854775807"
 
 # Maximum value (truncated).
-check value=9223372036854775807, buffer_size=18, idx=0, updated_idx=18, expected="922337203685477580"
-check value=9223372036854775807, buffer_size=17, idx=0, updated_idx=17, expected="92233720368547758"
-check value=9223372036854775807, buffer_size=16, idx=0, updated_idx=16, expected="9223372036854775"
-check value=9223372036854775807, buffer_size=15, idx=0, updated_idx=15, expected="922337203685477"
-check value=9223372036854775807, buffer_size=14, idx=0, updated_idx=14, expected="92233720368547"
-check value=9223372036854775807, buffer_size=13, idx=0, updated_idx=13, expected="9223372036854"
-check value=9223372036854775807, buffer_size=12, idx=0, updated_idx=12, expected="922337203685"
-check value=9223372036854775807, buffer_size=11, idx=0, updated_idx=11, expected="92233720368"
-check value=9223372036854775807, buffer_size=10, idx=0, updated_idx=10, expected="9223372036"
-check value=9223372036854775807, buffer_size=9, idx=0, updated_idx=9, expected="922337203"
-check value=9223372036854775807, buffer_size=8, idx=0, updated_idx=8, expected="92233720"
-check value=9223372036854775807, buffer_size=7, idx=0, updated_idx=7, expected="9223372"
-check value=9223372036854775807, buffer_size=6, idx=0, updated_idx=6, expected="922337"
-check value=9223372036854775807, buffer_size=5, idx=0, updated_idx=5, expected="92233"
-check value=9223372036854775807, buffer_size=4, idx=0, updated_idx=4, expected="9223"
-check value=9223372036854775807, buffer_size=3, idx=0, updated_idx=3, expected="922"
-check value=9223372036854775807, buffer_size=2, idx=0, updated_idx=2, expected="92"
-check value=9223372036854775807, buffer_size=1, idx=0, updated_idx=1, expected="9"
-check value=9223372036854775807, buffer_size=0, idx=0, updated_idx=0, expected=""
+pcheck value=9223372036854775807, buffer_size=18, idx=0, updated_idx=18, expected="922337203685477580"
+pcheck value=9223372036854775807, buffer_size=17, idx=0, updated_idx=17, expected="92233720368547758"
+pcheck value=9223372036854775807, buffer_size=16, idx=0, updated_idx=16, expected="9223372036854775"
+pcheck value=9223372036854775807, buffer_size=15, idx=0, updated_idx=15, expected="922337203685477"
+pcheck value=9223372036854775807, buffer_size=14, idx=0, updated_idx=14, expected="92233720368547"
+pcheck value=9223372036854775807, buffer_size=13, idx=0, updated_idx=13, expected="9223372036854"
+pcheck value=9223372036854775807, buffer_size=12, idx=0, updated_idx=12, expected="922337203685"
+pcheck value=9223372036854775807, buffer_size=11, idx=0, updated_idx=11, expected="92233720368"
+pcheck value=9223372036854775807, buffer_size=10, idx=0, updated_idx=10, expected="9223372036"
+pcheck value=9223372036854775807, buffer_size=9, idx=0, updated_idx=9, expected="922337203"
+pcheck value=9223372036854775807, buffer_size=8, idx=0, updated_idx=8, expected="92233720"
+pcheck value=9223372036854775807, buffer_size=7, idx=0, updated_idx=7, expected="9223372"
+pcheck value=9223372036854775807, buffer_size=6, idx=0, updated_idx=6, expected="922337"
+pcheck value=9223372036854775807, buffer_size=5, idx=0, updated_idx=5, expected="92233"
+pcheck value=9223372036854775807, buffer_size=4, idx=0, updated_idx=4, expected="9223"
+pcheck value=9223372036854775807, buffer_size=3, idx=0, updated_idx=3, expected="922"
+pcheck value=9223372036854775807, buffer_size=2, idx=0, updated_idx=2, expected="92"
+pcheck value=9223372036854775807, buffer_size=1, idx=0, updated_idx=1, expected="9"
+pcheck value=9223372036854775807, buffer_size=0, idx=0, updated_idx=0, expected=""
 
 # Maximum value (offset, truncation in all but first).
-check value=9223372036854775807, buffer_size=20, idx=1, updated_idx=20, expected="9223372036854775807"
-check value=9223372036854775807, buffer_size=19, idx=1, updated_idx=19, expected="922337203685477580"
-check value=9223372036854775807, buffer_size=18, idx=1, updated_idx=18, expected="92233720368547758"
-check value=9223372036854775807, buffer_size=17, idx=1, updated_idx=17, expected="9223372036854775"
-check value=9223372036854775807, buffer_size=16, idx=1, updated_idx=16, expected="922337203685477"
-check value=9223372036854775807, buffer_size=15, idx=1, updated_idx=15, expected="92233720368547"
-check value=9223372036854775807, buffer_size=14, idx=1, updated_idx=14, expected="9223372036854"
-check value=9223372036854775807, buffer_size=13, idx=1, updated_idx=13, expected="922337203685"
-check value=9223372036854775807, buffer_size=12, idx=1, updated_idx=12, expected="92233720368"
-check value=9223372036854775807, buffer_size=11, idx=1, updated_idx=11, expected="9223372036"
-check value=9223372036854775807, buffer_size=10, idx=1, updated_idx=10, expected="922337203"
-check value=9223372036854775807, buffer_size=9, idx=1, updated_idx=9, expected="92233720"
-check value=9223372036854775807, buffer_size=8, idx=1, updated_idx=8, expected="9223372"
-check value=9223372036854775807, buffer_size=7, idx=1, updated_idx=7, expected="922337"
-check value=9223372036854775807, buffer_size=6, idx=1, updated_idx=6, expected="92233"
-check value=9223372036854775807, buffer_size=5, idx=1, updated_idx=5, expected="9223"
-check value=9223372036854775807, buffer_size=4, idx=1, updated_idx=4, expected="922"
-check value=9223372036854775807, buffer_size=3, idx=1, updated_idx=3, expected="92"
-check value=9223372036854775807, buffer_size=2, idx=1, updated_idx=2, expected="9"
-check value=9223372036854775807, buffer_size=1, idx=1, updated_idx=1, expected=""
+pcheck value=9223372036854775807, buffer_size=20, idx=1, updated_idx=20, expected="9223372036854775807"
+pcheck value=9223372036854775807, buffer_size=19, idx=1, updated_idx=19, expected="922337203685477580"
+pcheck value=9223372036854775807, buffer_size=18, idx=1, updated_idx=18, expected="92233720368547758"
+pcheck value=9223372036854775807, buffer_size=17, idx=1, updated_idx=17, expected="9223372036854775"
+pcheck value=9223372036854775807, buffer_size=16, idx=1, updated_idx=16, expected="922337203685477"
+pcheck value=9223372036854775807, buffer_size=15, idx=1, updated_idx=15, expected="92233720368547"
+pcheck value=9223372036854775807, buffer_size=14, idx=1, updated_idx=14, expected="9223372036854"
+pcheck value=9223372036854775807, buffer_size=13, idx=1, updated_idx=13, expected="922337203685"
+pcheck value=9223372036854775807, buffer_size=12, idx=1, updated_idx=12, expected="92233720368"
+pcheck value=9223372036854775807, buffer_size=11, idx=1, updated_idx=11, expected="9223372036"
+pcheck value=9223372036854775807, buffer_size=10, idx=1, updated_idx=10, expected="922337203"
+pcheck value=9223372036854775807, buffer_size=9, idx=1, updated_idx=9, expected="92233720"
+pcheck value=9223372036854775807, buffer_size=8, idx=1, updated_idx=8, expected="9223372"
+pcheck value=9223372036854775807, buffer_size=7, idx=1, updated_idx=7, expected="922337"
+pcheck value=9223372036854775807, buffer_size=6, idx=1, updated_idx=6, expected="92233"
+pcheck value=9223372036854775807, buffer_size=5, idx=1, updated_idx=5, expected="9223"
+pcheck value=9223372036854775807, buffer_size=4, idx=1, updated_idx=4, expected="922"
+pcheck value=9223372036854775807, buffer_size=3, idx=1, updated_idx=3, expected="92"
+pcheck value=9223372036854775807, buffer_size=2, idx=1, updated_idx=2, expected="9"
+pcheck value=9223372036854775807, buffer_size=1, idx=1, updated_idx=1, expected=""
+
+# ===========================================================================
+# Test cases for negative numbers
+# ===========================================================================
+
+# Test all negative single digits (no space).
+#pcheck value=-1, buffer_size=0, idx=0, updated_idx=0, expected=""


### PR DESCRIPTION
This will be necessary to handle negative numbers in a graceful
way because the '-' cannot appear in symbol names. In the meantime,
having 'name' defined once improves the readability of the existing
implementation.