### PR TITLE
compile/scanner.Scan: inver order of size/data

### DIFF
--- a/cmd/compile/scanner/scan.S
+++ b/cmd/compile/scanner/scan.S
@@ -176,8 +176,8 @@ Xalign
 #
 # Output:
 #   a0 -> token_type (0 if none)
-#   a1 -> token_start
-#   a2 -> token_end
+#   a1 -> token_size
+#   a2 -> token_start
 #   a3 -> token_line
 #   a4 -> token_column
 .global "compile/scanner.Scan"
@@ -252,8 +252,8 @@ Xalign
 
 .Lscan_OK:
 	# a0 was set by an accepter and is the token type (or 0 if none).
-	mv a1, token_start
-	sub a2, token_end, token_start
+	sub a1, token_end, token_start
+	mv a2, token_start
 	mv a3, token_line
 	mv a4, token_column
 

--- a/cmd/compile/scanner/scan_test.S
+++ b/cmd/compile/scanner/scan_test.S
@@ -35,8 +35,8 @@ safe_str \name\()_input, "\value"
 
 	mv a0, a1
 	mv a1, a2
-	la a2, \start
-	li a3, \size
+	li a2, \size
+	la a3, \start
 	call "mem.Eq"
 	expect_nz a0
 .endm


### PR DESCRIPTION
This brings it inline with the current slice convention, where the
size goes before the data pointer.