### PR TITLE
compile/scanner: remove the period from the operator chars

### DIFF
--- a/cmd/compile/scanner/scan.S
+++ b/cmd/compile/scanner/scan.S
@@ -116,7 +116,7 @@ safe_str div_op, "/"
 safe_str separator_list, "()[]{};,."
 
 # Characters that can be part of an operator.
-safe_str operator_chars, "!%&*+-./:<=>?@^|~"
+safe_str operator_chars, "!%&*+-/:<=>?@^|~"
 
 
 # ===========================================================================


### PR DESCRIPTION
The access operator (.) is probably too important to be messed with.
Having it as a separator also gives us the opportunity to use it as
a postfix dereference operator. Whether we take it or not, it kind of
makes sense with the "period means access" theme:

  Foo.Bar # Type Bar on package Foo
  foo.bar # Field bar on struct foo
  p. = 3  # Assign 3 to the address pointed to by p, like *p = 3
  q.. = 7 # Assign 7 to the address pointed to by (q.), like **q = 7

That, in turn, allows us to use "@" as the operator to take the address
of a variable, replacing C's &.