### PR TITLE
grammar: minor readability change in scanner

### DIFF
--- a/prototypes/primordial/primordial.l
+++ b/prototypes/primordial/primordial.l
@@ -43,6 +43,8 @@ static int last_token = -1;
 
 \"(\\.|[^"\\])*\"      { emit(STR_LITERAL); }
 
+[ \t]+                 { /* ignore spaces */ }
+
 \n+                    {
 	/* Adapt BCPL's and Go's rules for automatic semicolons */
 	switch (last_token) {
@@ -64,8 +66,6 @@ static int last_token = -1;
 			/* No implicit semicolon */
 	}
 }
-
-[ \t]+                 { /* ignore spaces */ }
 
 .                      {
 	printf(


### PR DESCRIPTION
Move up a short section so that it doesn't get visually swallowed
between two larger blocks.