### PR TITLE
prototype: remove ReferenceType

### DIFF
--- a/prototypes/primordial/ast.hpp
+++ b/prototypes/primordial/ast.hpp
@@ -81,15 +81,6 @@ namespace AST {
 		std::unique_ptr<Type> item_type_;
 	};
 
-	class ReferenceType : public Type {
-	public:
-		ReferenceType() = default; // TODO replace
-		void print(std::ostream &os, int level=0) const override final;
-
-	private:
-		// TODO
-	};
-
 	class FunctionType : public Type {
 	public:
 		FunctionType() = default; // TODO replace

--- a/prototypes/primordial/primordial.y
+++ b/prototypes/primordial/primordial.y
@@ -132,7 +132,6 @@ yy::Parser::symbol_type yylex(void* yyscanner, yy::location& loc);
 %nterm <std::unique_ptr<AST::ArrayType>> ArrayType
 %nterm <std::unique_ptr<AST::SliceType>> SliceType
 %nterm <std::unique_ptr<AST::PointerType>> PointerType
-%nterm <std::unique_ptr<AST::ReferenceType>> ReferenceType
 %nterm <std::unique_ptr<AST::FunctionType>> FunctionType
 %nterm <std::unique_ptr<AST::StructType>> StructType
 %nterm <std::unique_ptr<AST::UnionType>> UnionType
@@ -569,7 +568,6 @@ Type
 	| ArrayType { $$ = std::move($1); }
 	| SliceType { $$ = std::move($1); }
 	| PointerType { $$ = std::move($1); }
-	| ReferenceType { $$ = std::move($1); }
 	| FunctionType { $$ = std::move($1); }
 	| StructType { $$ = std::move($1); }
 	| UnionType { $$ = std::move($1); }
@@ -604,10 +602,6 @@ SliceType : Type "[" "]" {
 
 PointerType : Type "?" {
 	$$ = std::make_unique<AST::PointerType>(std::move($1));
-};
-
-ReferenceType : Type "@" {
-	// TODO
 };
 
 FunctionType : "func" Signature {


### PR DESCRIPTION
A non-nullable reference is an obvious extension that we may want to
explore in the future, but strictly speaking we don't need it right
now for a high-level assembler.