### PR TITLE
Primordial: restrict QualifiedTypeName

### DIFF
--- a/prototypes/primordial/ast.cpp
+++ b/prototypes/primordial/ast.cpp
@@ -33,13 +33,12 @@ namespace AST {
 	}
 
 	QualifiedTypeName::QualifiedTypeName(
-		std::unique_ptr<Type> &&parent,
+		std::string &&package,
 		std::string &&name
-	) : parent_(std::move(parent)), name_(std::move(name)) {}
+	) : package_(std::move(package)), name_(std::move(name)) {}
 
 	void QualifiedTypeName::print(std::ostream &os, int level) const {
-		parent_->print(os, level);
-		os << "." << name_;
+		os << package_ << "." << name_;
 	}
 
 	ArrayType::ArrayType(

--- a/prototypes/primordial/ast.hpp
+++ b/prototypes/primordial/ast.hpp
@@ -29,11 +29,11 @@ namespace AST {
 
 	class QualifiedTypeName : public Type {
 	public:
-		QualifiedTypeName(std::unique_ptr<Type> &&parent, std::string &&name);
+		QualifiedTypeName(std::string &&package, std::string &&name);
 		void print(std::ostream &os, int level=0) const override final;
 
 	private:
-		std::unique_ptr<Type> parent_;
+		std::string package_;
 		std::string name_;
 	};
 

--- a/prototypes/primordial/primordial.y
+++ b/prototypes/primordial/primordial.y
@@ -577,7 +577,7 @@ TypeName : UPPER_ID {
 	$$ = std::make_unique<AST::TypeName>(std::move($1));
 };
 
-QualifiedTypeName : Type "." UPPER_ID {
+QualifiedTypeName : UPPER_ID "." UPPER_ID {
  	$$ = std::make_unique<AST::QualifiedTypeName>(
  		std::move($1),
  		std::move($3)


### PR DESCRIPTION
Like Go, it now only accepts package imports.