### PR TITLE
Primordial: insert semicolon after _

### DIFF
--- a/prototypes/primordial/primordial.l
+++ b/prototypes/primordial/primordial.l
@@ -187,6 +187,8 @@ static bool can_insert_semicolon = false;
 }
 
 "_" {
+	// For consistency with identifiers.
+	can_insert_semicolon = true;
 	return yy::Parser::make_OMIT(loc);
 }
 "import" {


### PR DESCRIPTION
While _ only appears on left-hand sides, we apply identifier rules for
consistency.